### PR TITLE
Resolve library database and search initialization crashes

### DIFF
--- a/Source/Managers/App Config/AppConfig.swift
+++ b/Source/Managers/App Config/AppConfig.swift
@@ -480,10 +480,17 @@ struct AppConfig {
     /// Migrate ke Bundle Mode pada first launch
     static func migrateToBundleMode() {
         // Clear custom folder setting jika ada
-        UserDefaults.standard.removeObject(forKey: customDatabaseFolderKey)
+        resetCustomModeKey()
 
         // Setup bundle mode
         _ = setupBundleMode()
+    }
+
+    /// Reset semua key custom database di UserDefaults
+    static func resetCustomModeKey() {
+        isUsingBundleMode = true
+        UserDefaults.standard.removeObject(forKey: AppConfig.customDatabaseFolderKey)
+        UserDefaults.standard.removeObject(forKey: AppConfig.storageKey)
     }
 
     /// Migrate ke Custom Mode: Switch dari Bundle ke user-selected folder

--- a/Source/Managers/App Config/SettingsActions.swift
+++ b/Source/Managers/App Config/SettingsActions.swift
@@ -156,6 +156,7 @@ enum SettingsActions {
         let migrateSuccess = AppConfig.migrateToCustomMode(folderUrl: url)
 
         if !migrateSuccess {
+            AppConfig.resetCustomModeKey()
             ReusableFunc.showAlert(
                 title: String(localized: "migrationFailed"),
                 message: String(localized: "migrationFailedInfo")

--- a/Source/Managers/Database/DatabaseManager.swift
+++ b/Source/Managers/Database/DatabaseManager.swift
@@ -158,7 +158,7 @@ class DatabaseManager {
     }
 
     private func handleSetupError() {
-        UserDefaults.standard.removeObject(forKey: AppConfig.storageKey)
+        AppConfig.resetCustomModeKey()
         ReusableFunc.showAlert(
             title: NSLocalizedString("Folder Not Found", comment: ""),
             message: NSLocalizedString(

--- a/Source/Managers/Database/LibraryDataManager.swift
+++ b/Source/Managers/Database/LibraryDataManager.swift
@@ -425,9 +425,11 @@ class LibraryDataManager {
         var totalTables = 0
 
         for archiveId in allowedByArchive.keys.sorted() {
+            if Task.isCancelled { return }
+            
             guard let archiveInfo = archives[archiveId] else { continue }
             guard let dbPath = getDatabasePath(forArchive: archiveId) else {
-                return
+                continue
             }
             let connections = createConnections(dbPath: dbPath, count: 4)
 
@@ -456,12 +458,13 @@ class LibraryDataManager {
             #endif
         }
 
-        if totalTables == 0 {
+        if totalTables == 0 || Task.isCancelled {
             return
         }
 
         searchEngine.checkAndResumeIfNeeded { [weak self] resumed in
             guard let self, !resumed else { return }
+            if Task.isCancelled { return }
 
             var completedTablesGlobal = 0
 

--- a/Source/Managers/Engine/SearchEngine.swift
+++ b/Source/Managers/Engine/SearchEngine.swift
@@ -446,6 +446,7 @@ final class SearchEngine {
     private var searchTask: Task<Void, Never>?
     private var isStopped = false
     private let stopLock = NSLock()
+    private let workersLock = NSLock()
 
     private var completedWorkers: Int = 0
     private let progressLock = NSLock()
@@ -455,7 +456,9 @@ final class SearchEngine {
     func registerDB(archiveId: String, tables: [String], connections: [DBConnectionType], batchSize: Int = 200) {
         let pool = SQLiteConnectionPool(conns: connections)
         let worker = SearchWorker(archiveId: archiveId, tables: tables, pool: pool, batchSize: batchSize)
+        workersLock.lock()
         workers.append(worker)
+        workersLock.unlock()
     }
 
     func startSearch(
@@ -479,11 +482,15 @@ final class SearchEngine {
         completedWorkers = 0
         progressLock.unlock()
 
-        print("=== MEMULAI SEARCH: \(workers.count) workers ===")
+        workersLock.lock()
+        let currentWorkers = workers
+        workersLock.unlock()
+
+        print("=== MEMULAI SEARCH: \(currentWorkers.count) workers ===")
 
         // Kirim total workers ke UI
         Task { @MainActor in
-            onInitialize(workers.count)
+            onInitialize(currentWorkers.count)
         }
 
         // Normalisasi keywords
@@ -507,9 +514,9 @@ final class SearchEngine {
             // Result: "الحمد OR حمد"
         }
 
-        searchTask = Task.detached(priority: .userInitiated) { [weak self, ftsQuery] in
+        searchTask = Task.detached(priority: .userInitiated) { [weak self, ftsQuery, currentWorkers] in
             guard let self else { return }
-            for worker in self.workers {
+            for worker in currentWorkers {
                 if isStopped { break }
 
                 var completedTables = 0
@@ -593,7 +600,9 @@ final class SearchEngine {
     }
 
     func cleanup() {
+        workersLock.lock()
         workers.removeAll()
+        workersLock.unlock()
     }
 }
 

--- a/Source/Managers/ViewModels/LibraryViewModel.swift
+++ b/Source/Managers/ViewModels/LibraryViewModel.swift
@@ -33,6 +33,7 @@ final class LibraryViewModel: ViewModelBase {
     var isBulkDownloading = false
     var isDownloadModal = false
     var singleBookToDelete: BooksData?
+    var reloadTask: Task<Void, Never>?
 
     #if os(macOS)
     @Published var searchQuery: String = ""
@@ -645,7 +646,14 @@ final class LibraryViewModel: ViewModelBase {
 
         addObserver(
             forName: .libraryFolderChanged, object: nil, queue: .current
-        ) { [weak self] _ in Task { @MainActor in await self?.refreshLibrary() } }
+        ) { [weak self] _ in
+            guard let self, reloadTask == nil else { return }
+            reloadTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await refreshLibrary()
+                reloadTask = nil
+            }
+        }
     }
 
     #if os(macOS)


### PR DESCRIPTION
**Library**
- **Fix:** Resolved a crash when switching library mode to bundle mode if the core database has not been downloaded yet. This was caused by multiple `.libraryFolderChanged` notifications being posted in rapid succession:
  - Download Success
  - Notification from `SettingsActions`

**Database**
- **Fix:** Handled cases where the custom database folder is missing required files. Previously on macOS, this caused an infinite loop where the app repeatedly asked to exit without resetting the `UserDefaults` key. Now, the invalid custom database key is properly deleted.

**Search**
- **Fix:** Resolved a crash that occurred when a user stopped a search while the book archives were still initializing.