### PR TITLE
fix: optimize book ID migration notifications

### DIFF
--- a/Source/Managers/BookUpdate/BookImportView.swift
+++ b/Source/Managers/BookUpdate/BookImportView.swift
@@ -850,8 +850,6 @@ struct OfflineImportFormView: View {
             }
 
             // Update UI
-            NotificationCenter.default.post(name: .bookIntegrated, object: oldId)
-            NotificationCenter.default.post(name: .bookIntegrated, object: newId)
             await setupData()
 
             selectedBookId = newId

--- a/Source/Managers/BookUpdate/BookImportView.swift
+++ b/Source/Managers/BookUpdate/BookImportView.swift
@@ -858,6 +858,11 @@ struct OfflineImportFormView: View {
 
             await MainActor.run {
                 HistoryViewModel.shared.migrateBookId(from: oldId, to: newId)
+                NotificationCenter.default.post(
+                    name: .bookIdMigrated,
+                    object: nil,
+                    userInfo: ["oldId": oldId, "newId": newId]
+                )
             }
 
             ReusableFunc.showAlert(

--- a/Source/Managers/Database/HistoryViewModel.swift
+++ b/Source/Managers/Database/HistoryViewModel.swift
@@ -23,7 +23,7 @@ private struct StoredReadingEntries: Codable {
     let entries: [ReadingEntry]
 }
 
-class HistoryViewModel: ObservableObject {
+class HistoryViewModel: ViewModelBase, ObservableObject {
     static let shared = HistoryViewModel()
 
     @Published private(set) var entriesByBookId: [Int: ReadingEntry] = [:]
@@ -87,7 +87,8 @@ class HistoryViewModel: ObservableObject {
             .map(\.bookId)
     }
 
-    private init() {
+    override init() {
+        super.init()
         loadFromUserDefaults()
         loadPendingSync()
 
@@ -99,6 +100,16 @@ class HistoryViewModel: ObservableObject {
 
         // Backfill missing CloudKit fields and upload to CloudKit
         backfillCloudKitFieldsIfNeeded()
+
+        addObserver(
+            forName: .bookIntegrated,
+            object: nil, queue: .main
+        ) { [weak self] _ in self?.loadBooksData() }
+
+        addObserver(
+            forName: .booksChanged,
+            object: nil, queue: .main
+        ) { [weak self] _ in self?.loadBooksData() }
     }
 
     // MARK: - Core Operations

--- a/Source/Managers/Database/LibraryDataManager.swift
+++ b/Source/Managers/Database/LibraryDataManager.swift
@@ -982,6 +982,7 @@ extension LibraryDataManager {
 extension Notification.Name {
     static let booksChanged = Notification.Name("booksChanged")
     static let bookIntegrated = Notification.Name("bookIntegrated")
+    static let bookIdMigrated = Notification.Name("bookIdMigrated")
 }
 
 // MARK: - Type-safe Posting Helper

--- a/Source/Managers/ViewModels/LibraryViewModel.swift
+++ b/Source/Managers/ViewModels/LibraryViewModel.swift
@@ -58,6 +58,7 @@ final class LibraryViewModel: ViewModelBase {
             updateDisplayedCategories()
         }
     }
+
     var _showOnlyDownloadedTracker: Bool = false
     var searchQuery: String = "" {
         didSet {
@@ -66,6 +67,7 @@ final class LibraryViewModel: ViewModelBase {
             }
         }
     }
+
     var showingDeleteConfirmation = false
     var showingImportSheet = false
     var importErrorMessage: String?
@@ -293,6 +295,29 @@ final class LibraryViewModel: ViewModelBase {
             updateSubject.send(.expandItem(nil))
         }
         #endif
+    }
+
+    // MARK: - Migration Support
+
+    func migrateBookId(from oldId: Int, to newId: Int) {
+        if selectedBookIds.contains(oldId) {
+            selectedBookIds.remove(oldId)
+            selectedBookIds.insert(newId)
+        }
+        if singleBookToDelete?.id == oldId {
+            singleBookToDelete = dataManager.getBook([newId]).first
+        }
+
+        // Reload all data references from the database manager (which was already reloaded in LibraryDataManager)
+        rootCategories = dataManager.allRootCategories
+        _hasBuiltAuthorHierarchy = false
+        if viewMode == .author {
+            _authorHierarchy = dataManager.buildAuthorHierarchy()
+            _hasBuiltAuthorHierarchy = true
+        }
+
+        // Apply the filter to rebuild baseCategories, displayedCategories, and bookLookup
+        applyFilter(filterMode)
     }
 
     // MARK: - Authors Pagination (Unified)
@@ -646,6 +671,18 @@ final class LibraryViewModel: ViewModelBase {
         }
 
         addObserver(
+            forName: .bookIdMigrated, object: nil, queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      let userInfo = notification.userInfo,
+                      let oldId = userInfo["oldId"] as? Int,
+                      let newId = userInfo["newId"] as? Int else { return }
+                migrateBookId(from: oldId, to: newId)
+            }
+        }
+
+        addObserver(
             forName: .libraryFolderChanged, object: nil, queue: .current
         ) { [weak self] _ in
             guard let self, reloadTask == nil else { return }
@@ -806,7 +843,7 @@ final class LibraryViewModel: ViewModelBase {
             return
         }
         guard let parent = findParentCategory(ofBookId: bookId, in: displayedCategories) else { return }
-        
+
         if isDownloadModal {
             parent.children.removeAll { ($0 as? BooksData)?.id == bookId }
             if parent.children.isEmpty {
@@ -1040,18 +1077,18 @@ final class LibraryViewModel: ViewModelBase {
         lookupQueue.enqueue { [weak self] in
             guard let self else { return }
             var newLookup: [String: (category: CategoryData, book: BooksData)] = [:]
-            
+
             func traverse(_ category: CategoryData) {
                 for child in category.children {
                     if let book = child as? BooksData { newLookup[book.book] = (category, book) }
                     else if let sub = child as? CategoryData { traverse(sub) }
                 }
             }
-            
+
             for category in displayedCategories {
                 traverse(category)
             }
-            
+
             bookLookup = newLookup
         }
     }

--- a/Source/Managers/ViewModels/ReaderViewModel.swift
+++ b/Source/Managers/ViewModels/ReaderViewModel.swift
@@ -636,6 +636,16 @@ extension ReaderViewModel {
         ) { [weak self] notification in
             Task { @MainActor in self?.handleBookIntegrated(notification) }
         }
+
+        addObserver(
+            forName: .bookIdMigrated,
+            object: nil, queue: .current
+        ) { [weak self] notification in
+            guard let userInfo = notification.userInfo,
+                  let oldId = userInfo["oldId"] as? Int,
+                  let newId = userInfo["newId"] as? Int else { return }
+            Task { @MainActor in self?.handleBookIdMigrated(oldId: oldId, newId: newId) }
+        }
         #endif
 
         #if os(iOS)
@@ -658,6 +668,13 @@ extension ReaderViewModel {
     }
 
     #if os(macOS)
+    func handleBookIdMigrated(oldId: Int, newId: Int) {
+        guard let current = currentBook, current.id == oldId else { return }
+        if let newBookData = LibraryDataManager.shared.booksById[newId] {
+            self.currentBook = newBookData
+        }
+    }
+
     func handleLibraryFolderChanged() {
         cleanUpState()
     }

--- a/Source/Managers/ViewModels/SearchViewModel.swift
+++ b/Source/Managers/ViewModels/SearchViewModel.swift
@@ -134,14 +134,6 @@ final class SearchViewModel: ViewModelBase {
         }
 
         addObserver(
-            forName: .bookIntegrated, object: nil, queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.refreshSubject.send(())
-            }
-        }
-
-        addObserver(
             forName: .booksChanged, object: nil, queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in

--- a/Source/Managers/ViewModels/SearchViewModel.swift
+++ b/Source/Managers/ViewModels/SearchViewModel.swift
@@ -148,7 +148,21 @@ final class SearchViewModel: ViewModelBase {
                 self?.refreshSubject.send(())
             }
         }
+
         #endif
+
+        addObserver(
+            forName: .bookIdMigrated, object: nil, queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor [weak self] in
+                guard let self = self,
+                      let userInfo = notification.userInfo,
+                      let oldId = userInfo["oldId"] as? Int,
+                      let newId = userInfo["newId"] as? Int else { return }
+
+                self.migrateBookId(from: oldId, to: newId)
+            }
+        }
 
         addObserver(
             forName: .libraryFolderChanged, object: nil, queue: .current
@@ -166,6 +180,36 @@ final class SearchViewModel: ViewModelBase {
                 state = .loaded
             }
         }
+    }
+
+    // MARK: - Migration Support
+
+    func migrateBookId(from oldId: Int, to newId: Int) {
+        if selectedBookIds.contains(oldId) {
+            selectedBookIds.remove(oldId)
+            selectedBookIds.insert(newId)
+        }
+
+        for i in 0..<results.count {
+            if results[i].bookId == oldId {
+                let oldItem = results[i]
+                results[i] = SearchResultItem(
+                    archive: oldItem.archive,
+                    tableName: "b\(newId)",
+                    bookId: newId,
+                    bookTitle: oldItem.bookTitle,
+                    page: oldItem.page,
+                    part: oldItem.part,
+                    attributedText: oldItem.attributedText
+                )
+            }
+        }
+
+        #if os(macOS)
+        if targetBookId == String(oldId) {
+            targetBookId = String(newId)
+        }
+        #endif
     }
 
     // MARK: - Library

--- a/Source/Reader/IbarotTextVC.swift
+++ b/Source/Reader/IbarotTextVC.swift
@@ -164,6 +164,26 @@ class IbarotTextVC: NSViewController {
                 }
             }
         }
+
+        NotificationCenter.default.addObserver(
+            forName: .bookIdMigrated,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let oldId = userInfo["oldId"] as? Int,
+                  let newId = userInfo["newId"] as? Int else { return }
+
+            if viewModel.currentBook?.id == oldId {
+                // ReaderViewModel handleBookIdMigrated will update its currentBook.
+                // We just need to make sure IbarotTextVC doesn't crash or holds onto stale state.
+                // Re-rendering or updating title can be triggered here if necessary.
+                if let newBookData = LibraryDataManager.shared.booksById[newId] {
+                    viewModel.currentBook = newBookData
+                }
+            }
+        }
     }
 
     // MARK: - State Accessors

--- a/Source/iOS/Managers/iOSNavigationManager.swift
+++ b/Source/iOS/Managers/iOSNavigationManager.swift
@@ -64,6 +64,42 @@ class iOSNavigationManager {
                 self?.clearAllTabs()
             }
         }
+
+        NotificationCenter.default.addObserver(
+            forName: .bookIdMigrated,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let oldId = userInfo["oldId"] as? Int,
+                  let newId = userInfo["newId"] as? Int else { return }
+            Task { @MainActor in
+                self.handleBookIdMigrated(oldId: oldId, newId: newId)
+            }
+        }
+    }
+
+    private func handleBookIdMigrated(oldId: Int, newId: Int) {
+        let ldm = LibraryDataManager.shared
+        guard let newBookData = ldm.booksById[newId] else { return }
+
+        for i in 0 ..< openTabs.count {
+            if openTabs[i].book.id == oldId {
+                let oldTab = openTabs[i]
+                openTabs[i] = ReaderTab(
+                    id: oldTab.id,
+                    book: newBookData,
+                    initialContentId: oldTab.initialContentId,
+                    viewModel: oldTab.viewModel
+                )
+                openTabs[i].viewModel.currentBook = newBookData
+            }
+        }
+
+        if selectedBook?.id == oldId {
+            selectedBook = newBookData
+        }
     }
 
     private func handleBookIntegrationChanged(bookId: Int) {
@@ -152,7 +188,7 @@ class iOSNavigationManager {
                 }
             }
 
-        case .single(let book, let initialContentId):
+        case let .single(book, initialContentId):
             state.mode = .downloading
             state.message = NSLocalizedString(
                 "Downloading book file from server...",
@@ -173,7 +209,7 @@ class iOSNavigationManager {
                     )
 
                     await MainActor.run {
-                        if !MaktabahApp.isIpad && self.selectedBook != nil {
+                        if !MaktabahApp.isIpad, self.selectedBook != nil {
                             // Do not automatically push a new book if there is already an active reader on iPhone
                         } else {
                             self.presentReader(book, initialContentId: initialContentId)
@@ -217,7 +253,7 @@ class iOSNavigationManager {
         await Task.yield()
 
         HistoryViewModel.shared.addBookToHistory(book.id)
-        if let initialContentId = initialContentId {
+        if let initialContentId {
             HistoryViewModel.shared.updateLastContentId(initialContentId, for: book.id)
         }
     }
@@ -228,7 +264,7 @@ class iOSNavigationManager {
     ) {
         // Prevent duplicate confirmation for the same book
         if activeIntegrationStates.contains(where: {
-            if case .single(let b, _) = $0.pendingData { return b.id == book.id }
+            if case let .single(b, _) = $0.pendingData { return b.id == book.id }
             return false
         }) {
             return


### PR DESCRIPTION
# Description

## Goal
Implement a centralized notification mechanism (`.bookIdMigrated`) to synchronize book ID updates across all active view models and navigation coordinators when a book's ID is migrated (e.g., via in-place offline import/migration). This prevents UI inconsistencies, stale references, and potential crashes.

---

## Detailed Changes

### 1. Notification Dispatch
* **OfflineImportFormView** in `BookImportView.swift`: Posts `.bookIdMigrated` with a payload of `["oldId": oldId, "newId": newId]` after database and local cache updates are ready.
* **LibraryDataManager**: Defined the static `.bookIdMigrated` notification name.

### 2. State & Reference Updates (macOS & iOS)
* **LibraryViewModel**: 
  * Replaces `oldId` with `newId` in `selectedBookIds`.
  * Migrates `singleBookToDelete` to reference the new book object.
  * Reloads categories and author hierarchies, then reapplies the active filter to refresh the lists.
* **SearchViewModel**:
  * Replaces `oldId` with `newId` in selected books.
  * Modifies search results containing `oldId` to use the migrated ID and updates the SQLite search table name format to `b{newId}`.
  * Adjusts the active macOS `targetBookId`.
* **ReaderViewModel** & **IbarotTextVC**: Updates the active `currentBook` reference on macOS if it matches the migrated ID.
* **iOSNavigationManager**: 
  * Replaces existing `ReaderTab` instances for the old book with a new `ReaderTab` holding the updated book model and updates the underlying tab view models.
  * Migrates the active `selectedBook` reference.

### 3. Base Updates & Cleanup
* **HistoryViewModel**: 
  * Inherits from `ViewModelBase` to utilize clean notification cleanup helpers.
  * Refreshes history books when `.bookIntegrated` and `.booksChanged` are posted.

---

## Verification
* Built both schemes successfully:
  * macOS scheme (`Maktabah-Direct`)
  * iOS Simulator scheme (`Maktabah-iOS`)
