### PR TITLE
fix(cloudkit): robust synchronization and conflict resolution

### DIFF
--- a/Source/Managers/Database/AnnotationManager/AnnMgr+CloudKit.swift
+++ b/Source/Managers/Database/AnnotationManager/AnnMgr+CloudKit.swift
@@ -15,6 +15,9 @@ extension AnnotationManager {
             if let count = try? _db.fetch(query: checkSql, parameters: [ckRecordId], mapping: { $0.int64(at: 0) }).first, count > 0 {
                 return // Delete wins
             }
+        } else if operation == "delete" {
+            let delSql = "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';"
+            try? _db.execute(query: delSql, parameters: [ckRecordId])
         }
         let sql = "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, ?, ?);"
         try? _db.execute(query: sql, parameters: [ckRecordId, operation, now])
@@ -54,8 +57,8 @@ extension AnnotationManager {
 
     // MARK: - Apply CloudKit Changes
 
-    func applyCloudKitChanges(annotationsToSave: [Annotation], recordIdsToDelete: [String]) {
-        guard let _db else { return }
+    @discardableResult func applyCloudKitChanges(annotationsToSave: [Annotation], recordIdsToDelete: [String]) -> Bool {
+        guard let _db else { return false }
 
         var addedAnnotations: [Annotation] = []
         var updatedAnnotations: [Annotation] = []
@@ -223,6 +226,8 @@ extension AnnotationManager {
             }
         } catch {
             print("AnnotationManager: Failed to apply CloudKit changes - \(error)")
+            return false
         }
+        return true
     }
 }

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -144,7 +144,11 @@ final class CloudKitSyncManager {
         }
 
         if !orphans.isEmpty {
+            // Orphan & Desync Cleanup: Prune record IDs from pending uploads if the local item no longer exists
             removePendingUploads(orphans)
+            AnnotationManager.shared.removePendingSync(ckRecordIds: orphans)
+            ResultsHandler.shared.removePendingSync(ckRecordIds: orphans)
+            HistoryViewModel.shared.removePendingSync(ckRecordIds: orphans)
         }
     }
 
@@ -449,6 +453,16 @@ final class CloudKitSyncManager {
             case .success:
                 self?.removePendingDeletes(ckRecordIds)
             case let .failure(error):
+                if let ckError = error as? CKError, ckError.code == .partialFailure,
+                   let partialErrors = ckError.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID: Error] {
+                    let failedIds = Set(partialErrors.keys.map(\.recordName))
+                    let successfulIds = ckRecordIds.filter { !failedIds.contains($0) }
+                    if !successfulIds.isEmpty {
+                        self?.removePendingDeletes(successfulIds)
+                    }
+                } else if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
+                    self?.removePendingDeletes(ckRecordIds)
+                }
                 self?.handleCloudKitError(error, operationType: .delete)
             }
         }
@@ -490,14 +504,15 @@ final class CloudKitSyncManager {
                     let records = fetchStateQueue.sync { changedRecords }
                     let deletes = fetchStateQueue.sync { deletedRecordIds }
 
+                    var applySuccess = true
                     if !records.isEmpty || !deletes.isEmpty {
-                        applyChangesLocally(
+                        applySuccess = self.applyChangesLocally(
                             recordsToSave: records,
                             recordIDsToDelete: deletes
                         )
                     }
 
-                    if let token = finalToken {
+                    if let token = finalToken, applySuccess {
                         core.saveToken(token)
                     }
 
@@ -518,10 +533,10 @@ final class CloudKitSyncManager {
         )
     }
 
-    private func applyChangesLocally(
+    @discardableResult private func applyChangesLocally(
         recordsToSave: [CKRecord],
         recordIDsToDelete: [CKRecord.ID]
-    ) {
+    ) -> Bool {
         var annotations: [Annotation] = []
         var folders: [SyncFolder] = []
         var searchResults: [SyncResult] = []
@@ -549,33 +564,41 @@ final class CloudKitSyncManager {
 
         let idsToDelete = recordIDsToDelete.map(\.recordName)
 
+        var success = true
+
         if !annotations.isEmpty || !idsToDelete.isEmpty {
-            AnnotationManager.shared.applyCloudKitChanges(
+            let annSuccess = AnnotationManager.shared.applyCloudKitChanges(
                 annotationsToSave: annotations,
                 recordIdsToDelete: idsToDelete
             )
+            success = success && annSuccess
         }
 
         if !folders.isEmpty || !idsToDelete.isEmpty {
-            ResultsHandler.shared.applyCloudKitFolderChanges(
+            let fldSuccess = ResultsHandler.shared.applyCloudKitFolderChanges(
                 foldersToSave: folders,
                 recordIdsToDelete: idsToDelete
             )
+            success = success && fldSuccess
         }
 
         if !searchResults.isEmpty || !idsToDelete.isEmpty {
-            ResultsHandler.shared.applyCloudKitResultChanges(
+            let resSuccess = ResultsHandler.shared.applyCloudKitResultChanges(
                 resultsToSave: searchResults,
                 recordIdsToDelete: idsToDelete
             )
+            success = success && resSuccess
         }
 
         if !historyEntries.isEmpty || !idsToDelete.isEmpty {
-            HistoryViewModel.shared.applyCloudKitChanges(
+            let histSuccess = HistoryViewModel.shared.applyCloudKitChanges(
                 entriesToSave: historyEntries,
                 recordIdsToDelete: idsToDelete
             )
+            success = success && histSuccess
         }
+
+        return success
     }
 
     // MARK: - Error Handling
@@ -613,8 +636,9 @@ final class CloudKitSyncManager {
                 completion?(result)
             }
         } else {
-            applyChangesLocally(recordsToSave: [serverRecord], recordIDsToDelete: [])
-            removePendingUploads([recordId])
+            if applyChangesLocally(recordsToSave: [serverRecord], recordIDsToDelete: []) {
+                removePendingUploads([recordId])
+            }
             completion?(.success(()))
         }
     }

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -455,12 +455,20 @@ final class CloudKitSyncManager {
             case let .failure(error):
                 if let ckError = error as? CKError, ckError.code == .partialFailure,
                    let partialErrors = ckError.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID: Error] {
-                    let failedIds = Set(partialErrors.keys.map(\.recordName))
-                    let successfulIds = ckRecordIds.filter { !failedIds.contains($0) }
-                    if !successfulIds.isEmpty {
-                        self?.removePendingDeletes(successfulIds)
+                    var idsToRemove = ckRecordIds.filter { !partialErrors.keys.map(\.recordName).contains($0) }
+                    for (recordID, itemError) in partialErrors {
+                        if let itemCKError = itemError as? CKError {
+                            if itemCKError.code == .unknownItem || itemCKError.code == .serverRecordChanged {
+                                idsToRemove.append(recordID.recordName)
+                            }
+                        }
+                    }
+                    if !idsToRemove.isEmpty {
+                        self?.removePendingDeletes(idsToRemove)
                     }
                 } else if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
+                    self?.removePendingDeletes(ckRecordIds)
+                } else if let ckError = error as? CKError, ckError.code == .unknownItem {
                     self?.removePendingDeletes(ckRecordIds)
                 }
                 self?.handleCloudKitError(error, operationType: .delete)

--- a/Source/Managers/Database/HistoryViewModel.swift
+++ b/Source/Managers/Database/HistoryViewModel.swift
@@ -332,8 +332,8 @@ class HistoryViewModel: ObservableObject {
         Array(entriesByBookId.values)
     }
 
-    func applyCloudKitChanges(entriesToSave: [ReadingEntry], recordIdsToDelete: [String]) {
-        DispatchQueue.main.async { [weak self] in
+    @discardableResult func applyCloudKitChanges(entriesToSave: [ReadingEntry], recordIdsToDelete: [String]) -> Bool {
+        let block = { [weak self] in
             guard let self else { return }
             var didChange = false
 
@@ -384,7 +384,17 @@ class HistoryViewModel: ObservableObject {
                 }
                 loadBooksData()
             }
+            _ = didChange
         }
+
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.sync {
+                block()
+            }
+        }
+        return true // Operations on UserDefaults and memory dictionaries cannot 'fail' like a SQLite transaction lock, so we always report success
     }
 
     // MARK: - Pending Sync Handling

--- a/Source/Managers/Database/ResultsHandler.swift
+++ b/Source/Managers/Database/ResultsHandler.swift
@@ -336,6 +336,9 @@ class ResultsHandler {
             if let count = try? db.fetch(query: checkSql, parameters: [ckRecordId], mapping: { $0.int64(at: 0) }).first, count > 0 {
                 return // Delete wins
             }
+        } else if operation == "delete" {
+            let delSql = "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';"
+            try? db.execute(query: delSql, parameters: [ckRecordId])
         }
         let now = Int64(Date().timeIntervalSince1970)
         let sql = "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, ?, ?);"
@@ -853,8 +856,8 @@ extension ResultsHandler {
 // MARK: - CloudKit Sync Apply
 
 extension ResultsHandler {
-    func applyCloudKitFolderChanges(foldersToSave: [SyncFolder], recordIdsToDelete: [String]) {
-        guard let db else { return }
+    @discardableResult func applyCloudKitFolderChanges(foldersToSave: [SyncFolder], recordIdsToDelete: [String]) -> Bool {
+        guard let db else { return false }
 
         do {
             try transaction {
@@ -972,11 +975,13 @@ extension ResultsHandler {
             }
         } catch {
             print("ResultsHandler: Failed to apply folder changes - \(error)")
+            return false
         }
+        return true
     }
 
-    func applyCloudKitResultChanges(resultsToSave: [SyncResult], recordIdsToDelete: [String]) {
-        guard let db else { return }
+    @discardableResult func applyCloudKitResultChanges(resultsToSave: [SyncResult], recordIdsToDelete: [String]) -> Bool {
+        guard let db else { return false }
 
         do {
             try transaction {
@@ -1097,6 +1102,8 @@ extension ResultsHandler {
             }
         } catch {
             print("ResultsHandler: Failed to apply result changes - \(error)")
+            return false
         }
+        return true
     }
 }


### PR DESCRIPTION
## Summary
Pull request ini menyelesaikan beberapa isu kritikal terkait keandalan (*reliability*) sinkronisasi CloudKit. Fokus utama perbaikan adalah mencegah terjadinya kehilangan data akibat *race condition* selama proses penyimpanan, serta menyelesaikan *infinite retry loop* yang menyumbat antrean *background sync* saat terjadi kegagalan parsial (*partial failure*).

## Key Changes
- **Transactional Token Saves:** Memastikan `CloudKitSyncManager` hanya memperbarui *sync token* (memajukan batas sinkronisasi) **setelah** seluruh penulisan ke database SQLite dan memori lokal (terutama di `HistoryViewModel`, `AnnotationManager`, dan `ResultsHandler`) berhasil secara keseluruhan (atomik).
- **"Delete Wins" Policy:** Mencegah masalah *zombie data* dengan secara proaktif menghapus perintah *upload* dari antrean apabila item yang sama juga dijadwalkan untuk dihapus.
- **Thread-safe UI Updates:** Memperbaiki celah *race condition* dengan mengeksekusi sinkronisasi memori di `HistoryViewModel` secara sinkron lewat `DispatchQueue.main.sync`, memastikan UI dan token tidak *out-of-sync*.
- **Orphan Cleanup:** Membersihkan tumpukan antrean CloudKit dengan mengidentifikasi dan menghapus data yatim (data yang antre untuk diunggah tapi file aslinya di lokal sudah terhapus).
- **Smart Partial Failure Handling:** Menyelesaikan *bug* fatal pada operasi penghapusan massal (*batch delete*). Sistem kini mengenali `CKError.unknownItem` (data sudah tidak ada di server) dan `CKError.serverRecordChanged` (konflik eksternal) sebagai proses yang terselesaikan, sehingga item-item tersebut langsung dibuang dari antrean alih-alih di-*retry* selamanya (*infinite loop*).

## Testing Steps
1. Putuskan sambungan internet (*Offline mode*).
2. Buat beberapa *highlight* atau riwayat baru, lalu langsung hapus salah satunya di perangkat yang sama.
3. Nyalakan kembali sambungan internet.
4. Perhatikan konsol di Xcode. Pastikan proses *background sync* berhasil mengosongkan antrean (`pending deletes` dan `pending uploads`) hingga tuntas tanpa tersangkut dalam putaran percobaan ulang (retry loop).
5. Uji perubahan riwayat bacaan besar-besaran (dari perangkat lain) dan pastikan aplikasi tidak *crash* ketika `HistoryViewModel` menyinkronisasikan UI.
