### PR TITLE
perf: Optimize tag database operations & clean up unused SearchEngine code

### DIFF
--- a/Source/Managers/Database/AnnotationManager/AnnMgr+Tags.swift
+++ b/Source/Managers/Database/AnnotationManager/AnnMgr+Tags.swift
@@ -60,11 +60,14 @@ extension AnnotationManager {
                     ann.tags = sanitizeTagNames(tags)
                     ann.lastModified = now
                     updatedAnnotations.append(ann)
-
-                    let insertRelSql = "INSERT OR IGNORE INTO \(annotationTagsTable) (\(colAnnotationTagAnnotationId), \(colAnnotationTagTagId)) VALUES (?, ?);"
-                    try exec(insertRelSql, parameters: [annId, existingNewTagId])
-                    try exec("UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) = ?;", parameters: [now, annId])
                 }
+
+                let insertRelSql = "INSERT OR IGNORE INTO \(annotationTagsTable) (\(colAnnotationTagAnnotationId), \(colAnnotationTagTagId)) SELECT \(colAnnotationTagAnnotationId), ? FROM \(annotationTagsTable) WHERE \(colAnnotationTagTagId) = ?;"
+                try exec(insertRelSql, parameters: [existingNewTagId, oldTagId])
+
+                let updateAnnSql = "UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) IN (SELECT \(colAnnotationTagAnnotationId) FROM \(annotationTagsTable) WHERE \(colAnnotationTagTagId) = ?);"
+                try exec(updateAnnSql, parameters: [now, oldTagId])
+
                 try exec("DELETE FROM \(annotationTagsTable) WHERE \(colAnnotationTagTagId) = ?;", parameters: [oldTagId])
                 try exec("DELETE FROM \(tagsTable) WHERE \(colTagId) = ?;", parameters: [oldTagId])
             }
@@ -79,8 +82,11 @@ extension AnnotationManager {
                     ann.tags = sanitizeTagNames(ann.tags)
                     ann.lastModified = now
                     updatedAnnotations.append(ann)
-                    try exec("UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) = ?;", parameters: [now, annId])
                 }
+
+                let updateAnnSql = "UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) IN (SELECT \(colAnnotationTagAnnotationId) FROM \(annotationTagsTable) WHERE \(colAnnotationTagTagId) = ?);"
+                try exec(updateAnnSql, parameters: [now, oldTagId])
+
                 let updateTagSql = "UPDATE \(tagsTable) SET \(colTagName) = ?, \(colTagNormalizedName) = ? WHERE \(colTagId) = ?;"
                 try exec(updateTagSql, parameters: [trimmedNew, newNormalized, oldTagId])
             }

--- a/Source/Managers/Database/AnnotationManager/AnnMgr+Tags.swift
+++ b/Source/Managers/Database/AnnotationManager/AnnMgr+Tags.swift
@@ -166,8 +166,19 @@ extension AnnotationManager {
         try transaction {
             try exec("DELETE FROM \(annotationTagsTable) WHERE \(colAnnotationTagTagId) = ?;", parameters: [deletedTagId])
             try exec("DELETE FROM \(tagsTable) WHERE \(colTagId) = ?;", parameters: [deletedTagId])
-            for annId in affectedIds {
-                try exec("UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) = ?;", parameters: [now, annId])
+
+            let chunkSize = 500
+            for chunkStart in stride(from: 0, to: affectedIds.count, by: chunkSize) {
+                let chunkEnd = min(chunkStart + chunkSize, affectedIds.count)
+                let chunk = Array(affectedIds[chunkStart..<chunkEnd])
+
+                let placeholders = String(repeating: "?,", count: chunk.count).dropLast()
+                let updateSql = "UPDATE \(annotationsTable) SET \(colAnnLastModified) = ? WHERE \(colAnnId) IN (\(placeholders));"
+
+                var parameters: [Any] = [now]
+                parameters.append(contentsOf: chunk)
+
+                try exec(updateSql, parameters: parameters)
             }
         }
 

--- a/Source/Managers/Engine/SearchEngine.swift
+++ b/Source/Managers/Engine/SearchEngine.swift
@@ -231,7 +231,6 @@ class SearchWorker {
         // ✅ KUNCI: Gunakan actor untuk koordinasi cancel
         actor CancelCoordinator {
             var shouldCancel = false
-            var resultCount = 0
 
             func checkCancel(_ stopFlag: @escaping @Sendable () -> Bool) -> Bool {
                 if stopFlag() || shouldCancel {
@@ -241,13 +240,7 @@ class SearchWorker {
                 return false
             }
 
-            func incrementResult() {
-                resultCount += 1
-            }
 
-            func getResultCount() -> Int {
-                resultCount
-            }
         }
 
         let coordinator = CancelCoordinator()
@@ -454,8 +447,6 @@ final class SearchEngine {
     private let stopLock = NSLock()
     private let workersLock = NSLock()
 
-    private var completedWorkers: Int = 0
-    private let progressLock = NSLock()
 
     init() {}
 
@@ -483,9 +474,6 @@ final class SearchEngine {
         searchTask = nil
         isStopped = false
 
-        progressLock.lock()
-        completedWorkers = 0
-        progressLock.unlock()
 
         workersLock.lock()
         let currentWorkers = workers
@@ -550,11 +538,8 @@ final class SearchEngine {
                         guard let self else { return true }
                         return isStopped
                     },
-                    onComplete: { [weak self] in
+                    onComplete: {
                         // Worker selesai
-                        self?.progressLock.lock()
-                        self?.completedWorkers += 1
-                        self?.progressLock.unlock()
                     }
                 )
             }


### PR DESCRIPTION
#### Summary
This PR improves performance for annotation tag database operations by eliminating N+1 queries, while also cleaning up dead code in `SearchEngine`.

---

#### Key Changes

1. **Tag Operations Optimization (AnnMgr+Tags.swift)**
   - **`renameTag` (Merge & Simple Rename)**: Replaced per-annotation SQL execution loops with set-based batch SQL queries (`INSERT OR IGNORE INTO ... SELECT` and `UPDATE ... WHERE IN (SELECT ...)`).
   - **`deleteTag`**: Replaced individual per-annotation updates for `lastModified` with chunked batch updates (chunk size of 500 IDs per `IN (...)` query).

2. **Refactoring & Cleanup (SearchEngine.swift)**
   - Removed unused actor properties and methods in `CancelCoordinator` (`resultCount`, `incrementResult`, `getResultCount`) and `SearchEngine` (`completedWorkers`, `progressLock`).

---

#### Potential Bugs & UI Impact Analysis

- **Database Bug Risks**:
  - In `renameTag`, the `UPDATE` query runs prior to deleting `oldTagId` records from `annotationTagsTable`, guaranteeing that `lastModified` is correctly updated for all affected annotations.
  - The 500-ID chunking limit in `deleteTag` prevents exceeding SQLite's maximum query parameter limit.
- **UI Inconsistency Risks**:
  - **No UI inconsistency risks detected**. In-memory cache updates (`_cacheById`, `_cacheByContent`, `_cacheByBook`) and downstream UI synchronization (`applyBatchTagUpdates` / `deleteTagFromTree`) are preserved.
- **SearchEngine Cleanup**:
  - `completedWorkers` and `progressLock` were only ever incremented and never read elsewhere in the app for progress UI, so removing them is a risk-free dead-code removal.

---

#### Modified Files
- `Source/Managers/Database/AnnotationManager/AnnMgr+Tags.swift`
- `Source/Managers/Engine/SearchEngine.swift`