### PR TITLE
fix(cloudkit): optimize queue performance, orphan record resolution, and iOS UI state sync

### DIFF
--- a/Source/Managers/App Config/AppConfig.swift
+++ b/Source/Managers/App Config/AppConfig.swift
@@ -638,6 +638,10 @@ struct AppConfig {
             setupAnnotationsAndResults()
 
             CloudKitSyncManager.shared.setupAndInitialSync()
+        } else {
+            // Reset flag agar saat re-enable, uploadAllLocalData jalan kembali
+            // sehingga data yang dibuat saat CloudKit off tidak terlewat
+            UserDefaults.standard.removeObject(forKey: "CloudKitSyncManager_InitialUploadDone")
         }
         DispatchQueue.main.async { completion(nil) }
     }

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -46,6 +46,7 @@ final class CloudKitSyncManager {
     }
 
     private func retryAllPendingOperations() {
+        guard AppConfig.useICloud else { return }
         syncQueue.async(flags: .barrier) { [weak self] in
             self?.retryPendingUploads()
             self?.retryPendingDeletes()
@@ -205,21 +206,27 @@ final class CloudKitSyncManager {
     }
 
     private func performInitialUploadCheck() {
+        // Jika initial upload belum pernah dilakukan, backfill hanya assign ckRecordId
+        // tanpa upload — uploadAllLocalData yang akan handle semuanya sekaligus.
+        // Jika initial upload sudah selesai (re-enable), backfill sekaligus upload
+        // agar data yang dibuat saat CloudKit off tidak terlewat.
+        let isInitialUpload = !UserDefaults.standard.bool(forKey: "CloudKitSyncManager_InitialUploadDone")
+
         if let _ = AnnotationManager.shared.db {
             try? AnnotationManager.shared.backfillCloudKitFieldsIfNeeded { [weak self] backfilled in
-                if !backfilled.isEmpty { self?.upload(annotations: backfilled) }
+                if !isInitialUpload, !backfilled.isEmpty { self?.upload(annotations: backfilled) }
             }
         }
 
         if let _ = ResultsHandler.shared.db {
-            try? ResultsHandler.shared.backfillResultsCloudKitFieldsIfNeeded()
+            try? ResultsHandler.shared.backfillResultsCloudKitFieldsIfNeeded(uploadIfNeeded: !isInitialUpload)
         }
 
         HistoryViewModel.shared.backfillCloudKitFieldsIfNeeded { [weak self] backfilled in
-            if !backfilled.isEmpty { self?.uploadHistory(entries: backfilled) }
+            if !isInitialUpload, !backfilled.isEmpty { self?.uploadHistory(entries: backfilled) }
         }
 
-        if !UserDefaults.standard.bool(forKey: "CloudKitSyncManager_InitialUploadDone") {
+        if isInitialUpload {
             uploadAllLocalData { success in
                 if success {
                     UserDefaults.standard.set(true, forKey: "CloudKitSyncManager_InitialUploadDone")

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -106,8 +106,9 @@ final class CloudKitSyncManager {
 
         // Paginated or direct DB fetch is recommended here, but we keep existing logic compatible
         if !annPending.isEmpty {
+            let annPendingSet = Set(annPending)
             let allAnnotations = AnnotationManager.shared.loadAnnotations()
-            let toUploadAnn = allAnnotations.filter { annPending.contains($0.ckRecordId ?? "") }
+            let toUploadAnn = allAnnotations.filter { annPendingSet.contains($0.ckRecordId ?? "") }
             if !toUploadAnn.isEmpty {
                 upload(annotations: toUploadAnn)
             }
@@ -117,11 +118,12 @@ final class CloudKitSyncManager {
         }
 
         if !resPending.isEmpty {
+            let resPendingSet = Set(resPending)
             let allFolders = ResultsHandler.shared.fetchAllSyncFolders()
-            let toUploadFolders = allFolders.filter { resPending.contains($0.ckRecordId ?? "") }
+            let toUploadFolders = allFolders.filter { resPendingSet.contains($0.ckRecordId ?? "") }
 
             let allResults = ResultsHandler.shared.fetchAllSyncResults()
-            let toUploadResults = allResults.filter { resPending.contains($0.ckRecordId ?? "") }
+            let toUploadResults = allResults.filter { resPendingSet.contains($0.ckRecordId ?? "") }
 
             if !toUploadFolders.isEmpty || !toUploadResults.isEmpty {
                 uploadResultsData(folders: toUploadFolders, results: toUploadResults)
@@ -134,8 +136,9 @@ final class CloudKitSyncManager {
         }
 
         if !histPending.isEmpty {
+            let histPendingSet = Set(histPending)
             let allHist = HistoryViewModel.shared.getAllEntries()
-            let toUploadHist = allHist.filter { histPending.contains($0.ckRecordId ?? "") }
+            let toUploadHist = allHist.filter { histPendingSet.contains($0.ckRecordId ?? "") }
             if !toUploadHist.isEmpty {
                 uploadHistory(entries: toUploadHist)
             }
@@ -365,6 +368,14 @@ final class CloudKitSyncManager {
     ) {
         guard AppConfig.useICloud else { completion?(.success(())); return }
 
+        let pendingFolderIds = folders.compactMap(\.ckRecordId)
+        let pendingResultIds = results.compactMap(\.ckRecordId)
+        let pendingIds = pendingFolderIds + pendingResultIds
+
+        if !pendingIds.isEmpty {
+            addPendingUploads(pendingIds, target: .result)
+        }
+
         syncQueue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
             var records: [CKRecord] = []
@@ -385,7 +396,6 @@ final class CloudKitSyncManager {
             }
 
             let ids = records.map(\.recordID.recordName)
-            addPendingUploads(ids, target: .result)
 
             core.upload(records: records) { [weak self] result in
                 self?.handleUploadResult(
@@ -404,6 +414,11 @@ final class CloudKitSyncManager {
     ) {
         guard AppConfig.useICloud else { completion?(.success(())); return }
 
+        let pendingIds = entries.compactMap(\.ckRecordId)
+        if !pendingIds.isEmpty {
+            addPendingUploads(pendingIds, target: .history)
+        }
+
         syncQueue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
             let records = entries.compactMap { $0.toCKRecord(zoneID: self.core.zoneId) }
@@ -413,7 +428,6 @@ final class CloudKitSyncManager {
             }
 
             let ids = records.map(\.recordID.recordName)
-            addPendingUploads(ids, target: .history)
 
             core.upload(records: records) { [weak self] result in
                 self?.handleUploadResult(
@@ -519,21 +533,25 @@ final class CloudKitSyncManager {
                     let records = fetchStateQueue.sync { changedRecords }
                     let deletes = fetchStateQueue.sync { deletedRecordIds }
 
-                    var applySuccess = true
-                    if !records.isEmpty || !deletes.isEmpty {
-                        applySuccess = self.applyChangesLocally(
-                            recordsToSave: records,
-                            recordIDsToDelete: deletes
-                        )
-                    }
+                    self.syncQueue.async {
+                        var applySuccess = true
+                        if !records.isEmpty || !deletes.isEmpty {
+                            applySuccess = self.applyChangesLocally(
+                                recordsToSave: records,
+                                recordIDsToDelete: deletes
+                            )
+                        }
 
-                    if let token = finalToken, applySuccess {
-                        core.saveToken(token)
-                    }
+                        DispatchQueue.main.async {
+                            if let token = finalToken, applySuccess {
+                                self.core.saveToken(token)
+                            }
 
-                    core.setSyncing(false) {
-                        if moreComing {
-                            self.fetchChanges(retryCount: 0)
+                            self.core.setSyncing(false) {
+                                if moreComing {
+                                    self.fetchChanges(retryCount: 0)
+                                }
+                            }
                         }
                     }
                 case let .failure(error):

--- a/Source/Managers/Database/DatabaseManager.swift
+++ b/Source/Managers/Database/DatabaseManager.swift
@@ -430,4 +430,53 @@ class DatabaseManager {
         lock.unlock()
         IntegrationCache.shared.invalidate(archiveId: archiveId)
     }
+
+    static func validateDatabaseFolder(_ url: URL) -> Error? {
+        let fm = FileManager.default
+        let mainFolder = url.appendingPathComponent("Files", isDirectory: true)
+
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: mainFolder.path, isDirectory: &isDir), isDir.boolValue else {
+            return NSError(domain: "Maktabah", code: 1, userInfo: [NSLocalizedDescriptionKey: "Folder 'Files' is missing."])
+        }
+
+        let mainSqlite = mainFolder.appendingPathComponent("main.sqlite")
+        let specialSqlite = mainFolder.appendingPathComponent("special.sqlite")
+
+        guard fm.fileExists(atPath: mainSqlite.path), fm.fileExists(atPath: specialSqlite.path) else {
+            return NSError(domain: "Maktabah", code: 2, userInfo: [NSLocalizedDescriptionKey: "main.sqlite or special.sqlite is missing in the 'Files' folder."])
+        }
+
+        let mainSize = (try? fm.attributesOfItem(atPath: mainSqlite.path)[.size] as? NSNumber)?.int64Value ?? 0
+        let specialSize = (try? fm.attributesOfItem(atPath: specialSqlite.path)[.size] as? NSNumber)?.int64Value ?? 0
+
+        guard mainSize > 0, specialSize > 0 else {
+            return NSError(domain: "Maktabah", code: 3, userInfo: [NSLocalizedDescriptionKey: "Database files are empty."])
+        }
+
+        do {
+            let dbMain = try SQLiteDatabase(path: mainSqlite.path, flags: SQLITE_OPEN_READONLY)
+            let dbSpecial = try SQLiteDatabase(path: specialSqlite.path, flags: SQLITE_OPEN_READONLY)
+
+            let checkTable = { (db: SQLiteDatabase, table: String) throws in
+                var exists = false
+                let query = "SELECT name FROM sqlite_master WHERE type='table' AND name='\(table)'"
+                try db.fetch(query: query) { _ in exists = true }
+                if !exists {
+                    throw NSError(domain: "Maktabah", code: 4, userInfo: [NSLocalizedDescriptionKey: "Table '\(table)' is missing in database."])
+                }
+            }
+
+            try checkTable(dbMain, "0bok")
+            try checkTable(dbMain, "0cat")
+            try checkTable(dbMain, "v")
+
+            try checkTable(dbSpecial, "Auth")
+            try checkTable(dbSpecial, "shorts")
+        } catch {
+            return error
+        }
+
+        return nil
+    }
 }

--- a/Source/Managers/Database/HistoryViewModel.swift
+++ b/Source/Managers/Database/HistoryViewModel.swift
@@ -431,7 +431,9 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         pendingQueue.sync(flags: .barrier) { [weak self] in
             guard let self else { return }
             if operation == "upload" {
-                pendingDeletes.remove(ckRecordId)
+                if pendingDeletes.contains(ckRecordId) {
+                    return // Delete wins
+                }
                 pendingUploads.insert(ckRecordId)
             } else {
                 pendingUploads.remove(ckRecordId)

--- a/Source/Managers/Database/ResultsHandler.swift
+++ b/Source/Managers/Database/ResultsHandler.swift
@@ -231,7 +231,7 @@ class ResultsHandler {
         }
     }
 
-    func backfillResultsCloudKitFieldsIfNeeded() throws {
+    func backfillResultsCloudKitFieldsIfNeeded(uploadIfNeeded: Bool = true) throws {
         guard let db else { return }
         let now = Int64(Date().timeIntervalSince1970)
 
@@ -321,6 +321,7 @@ class ResultsHandler {
         }
 
         if !foldersToUpload.isEmpty || !resultsToUpload.isEmpty {
+            guard uploadIfNeeded else { return }
             DispatchQueue.global(qos: .background).async {
                 CloudKitSyncManager.shared.uploadResultsData(folders: foldersToUpload, results: resultsToUpload)
             }

--- a/Source/Managers/Database/ResultsHandler.swift
+++ b/Source/Managers/Database/ResultsHandler.swift
@@ -101,6 +101,8 @@ class ResultsHandler {
         }
 
         createTables()
+        resolveOrphanFolders()
+        resolveOrphanResults()
 
         if isNewDatabase {
             CloudKitSyncManager.shared.resetChangeToken()
@@ -907,48 +909,59 @@ extension ResultsHandler {
 
                     var existingLocalId: Int64 = -1
                     var localLastMod: Int64 = 0
-                    let findSql = "SELECT \(colId), \(colLastModified) FROM \(foldersTable) WHERE \(colCkRecordId) = ? LIMIT 1"
-                    if let row = try db.fetch(query: findSql, parameters: [ckId], mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
+                    var existingParentId: Int64? = nil
+                    let findSql = "SELECT \(colId), \(colLastModified), \(colParent) FROM \(foldersTable) WHERE \(colCkRecordId) = ? LIMIT 1"
+                    if let row = try db.fetch(query: findSql, parameters: [ckId], mapping: { ($0.int64(at: 0), $0.int64(at: 1), !$0.isNull(at: 2) ? $0.int64(at: 2) : nil) }).first {
                         existingLocalId = row.0
                         localLastMod = row.1
+                        existingParentId = row.2
                     }
 
                     if existingLocalId != -1 {
                         let remoteLastMod = folder.lastModified ?? 0
                         if remoteLastMod >= localLastMod {
-                            let conflictSql: String
-                            let conflictParams: [Any]
-                            if let pid = pLocalId {
-                                conflictSql = "SELECT \(colId) FROM \(foldersTable) WHERE \(colParent) = ? AND \(colName) = ? AND \(colId) != ? LIMIT 1"
-                                conflictParams = [pid, folder.name, existingLocalId]
-                            } else {
-                                conflictSql = "SELECT \(colId) FROM \(foldersTable) WHERE \(colParent) IS NULL AND \(colName) = ? AND \(colId) != ? LIMIT 1"
-                                conflictParams = [folder.name, existingLocalId]
-                            }
-                            if let conflictId = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { $0.int64(at: 0) }).first {
-                                try exec("DELETE FROM \(foldersTable) WHERE \(colId) = ?;", parameters: [conflictId])
+                            let isOrphan = folder.parentCkRecordId != nil && pLocalId == nil
+                            let newParentForDb = isOrphan ? existingParentId : pLocalId
+
+                            if !isOrphan || newParentForDb != nil {
+                                let conflictSql: String
+                                let conflictParams: [Any]
+                                if let pid = newParentForDb {
+                                    conflictSql = "SELECT \(colId) FROM \(foldersTable) WHERE \(colParent) = ? AND \(colName) = ? AND \(colId) != ? LIMIT 1"
+                                    conflictParams = [pid, folder.name, existingLocalId]
+                                } else {
+                                    conflictSql = "SELECT \(colId) FROM \(foldersTable) WHERE \(colParent) IS NULL AND \(colName) = ? AND \(colId) != ? LIMIT 1"
+                                    conflictParams = [folder.name, existingLocalId]
+                                }
+                                if let conflictId = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { $0.int64(at: 0) }).first {
+                                    try exec("DELETE FROM \(foldersTable) WHERE \(colId) = ?;", parameters: [conflictId])
+                                }
                             }
 
                             let upSql = "UPDATE \(foldersTable) SET \(colName) = ?, \(colLastModified) = ?, \(colParentCkRecordId) = ?, \(colParent) = ? WHERE \(colId) = ?;"
-                            try db.execute(query: upSql, parameters: [folder.name, folder.lastModified ?? 0, folder.parentCkRecordId ?? NSNull(), pLocalId ?? NSNull(), existingLocalId])
+                            try db.execute(query: upSql, parameters: [folder.name, folder.lastModified ?? 0, folder.parentCkRecordId ?? NSNull(), newParentForDb ?? NSNull(), existingLocalId])
                         }
                     } else {
                         var conflictLocalId: Int64 = -1
                         var conflictLastMod: Int64 = 0
 
-                        let conflictSql: String
-                        let conflictParams: [Any]
-                        if let pid = pLocalId {
-                            conflictSql = "SELECT \(colId), \(colLastModified) FROM \(foldersTable) WHERE \(colParent) = ? AND \(colName) = ? LIMIT 1"
-                            conflictParams = [pid, folder.name]
-                        } else {
-                            conflictSql = "SELECT \(colId), \(colLastModified) FROM \(foldersTable) WHERE \(colParent) IS NULL AND \(colName) = ? LIMIT 1"
-                            conflictParams = [folder.name]
-                        }
+                        let isOrphan = folder.parentCkRecordId != nil && pLocalId == nil
+                        
+                        if !isOrphan {
+                            let conflictSql: String
+                            let conflictParams: [Any]
+                            if let pid = pLocalId {
+                                conflictSql = "SELECT \(colId), \(colLastModified) FROM \(foldersTable) WHERE \(colParent) = ? AND \(colName) = ? LIMIT 1"
+                                conflictParams = [pid, folder.name]
+                            } else {
+                                conflictSql = "SELECT \(colId), \(colLastModified) FROM \(foldersTable) WHERE \(colParent) IS NULL AND \(colName) = ? LIMIT 1"
+                                conflictParams = [folder.name]
+                            }
 
-                        if let row = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
-                            conflictLocalId = row.0
-                            conflictLastMod = row.1
+                            if let row = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
+                                conflictLocalId = row.0
+                                conflictLastMod = row.1
+                            }
                         }
 
                         if conflictLocalId != -1 {
@@ -967,6 +980,8 @@ extension ResultsHandler {
                     }
                 }
             }
+
+            resolveOrphanFolders()
 
             // Post notification for UI refresh
             DispatchQueue.main.async {
@@ -1004,26 +1019,33 @@ extension ResultsHandler {
 
                     var existingLocalId: Int64 = -1
                     var localLastMod: Int64 = 0
-                    let findResSql = "SELECT \(colId), \(colResLastModified) FROM \(resultsTable) WHERE \(colResCkRecordId) = ? LIMIT 1"
-                    if let row = try db.fetch(query: findResSql, parameters: [ckId], mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
+                    var existingFolderId: Int64? = nil
+                    let findResSql = "SELECT \(colId), \(colResLastModified), \(colFolderId) FROM \(resultsTable) WHERE \(colResCkRecordId) = ? LIMIT 1"
+                    if let row = try db.fetch(query: findResSql, parameters: [ckId], mapping: { ($0.int64(at: 0), $0.int64(at: 1), !$0.isNull(at: 2) ? $0.int64(at: 2) : nil) }).first {
                         existingLocalId = row.0
                         localLastMod = row.1
+                        existingFolderId = row.2
                     }
 
                     if existingLocalId != -1 {
                         let remoteLastMod = res.lastModified ?? 0
                         if remoteLastMod >= localLastMod {
-                            let conflictSql: String
-                            let conflictParams: [Any]
-                            if let fid = fLocalId {
-                                conflictSql = "SELECT \(colId) FROM \(resultsTable) WHERE \(colFolderId) = ? AND \(colName) = ? AND \(colBkId) = ? AND \(colId) != ? LIMIT 1"
-                                conflictParams = [fid, res.name, res.bkId, existingLocalId]
-                            } else {
-                                conflictSql = "SELECT \(colId) FROM \(resultsTable) WHERE \(colFolderId) IS NULL AND \(colName) = ? AND \(colBkId) = ? AND \(colId) != ? LIMIT 1"
-                                conflictParams = [res.name, res.bkId, existingLocalId]
-                            }
-                            if let conflictId = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { $0.int64(at: 0) }).first {
-                                try exec("DELETE FROM \(resultsTable) WHERE \(colId) = ?;", parameters: [conflictId])
+                            let isOrphan = res.folderCkRecordId != nil && fLocalId == nil
+                            let newFolderForDb = isOrphan ? existingFolderId : fLocalId
+
+                            if !isOrphan || newFolderForDb != nil {
+                                let conflictSql: String
+                                let conflictParams: [Any]
+                                if let fid = newFolderForDb {
+                                    conflictSql = "SELECT \(colId) FROM \(resultsTable) WHERE \(colFolderId) = ? AND \(colName) = ? AND \(colBkId) = ? AND \(colId) != ? LIMIT 1"
+                                    conflictParams = [fid, res.name, res.bkId, existingLocalId]
+                                } else {
+                                    conflictSql = "SELECT \(colId) FROM \(resultsTable) WHERE \(colFolderId) IS NULL AND \(colName) = ? AND \(colBkId) = ? AND \(colId) != ? LIMIT 1"
+                                    conflictParams = [res.name, res.bkId, existingLocalId]
+                                }
+                                if let conflictId = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { $0.int64(at: 0) }).first {
+                                    try exec("DELETE FROM \(resultsTable) WHERE \(colId) = ?;", parameters: [conflictId])
+                                }
                             }
 
                             let upSql = """
@@ -1033,7 +1055,7 @@ extension ResultsHandler {
                             WHERE \(colId) = ?;
                             """
                             let params: [Any] = [
-                                fLocalId ?? NSNull(), res.name, res.query, res.archive,
+                                newFolderForDb ?? NSNull(), res.name, res.query, res.archive,
                                 res.bkId, res.contentId, res.lastModified ?? 0, res.folderCkRecordId ?? NSNull(),
                                 existingLocalId,
                             ]
@@ -1043,19 +1065,23 @@ extension ResultsHandler {
                         var conflictLocalId: Int64 = -1
                         var conflictLastMod: Int64 = 0
 
-                        let conflictSql: String
-                        let conflictParams: [Any]
-                        if let fid = fLocalId {
-                            conflictSql = "SELECT \(colId), \(colResLastModified) FROM \(resultsTable) WHERE \(colFolderId) = ? AND \(colName) = ? AND \(colBkId) = ? LIMIT 1"
-                            conflictParams = [fid, res.name, res.bkId]
-                        } else {
-                            conflictSql = "SELECT \(colId), \(colResLastModified) FROM \(resultsTable) WHERE \(colFolderId) IS NULL AND \(colName) = ? AND \(colBkId) = ? LIMIT 1"
-                            conflictParams = [res.name, res.bkId]
-                        }
+                        let isOrphan = res.folderCkRecordId != nil && fLocalId == nil
 
-                        if let row = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
-                            conflictLocalId = row.0
-                            conflictLastMod = row.1
+                        if !isOrphan {
+                            let conflictSql: String
+                            let conflictParams: [Any]
+                            if let fid = fLocalId {
+                                conflictSql = "SELECT \(colId), \(colResLastModified) FROM \(resultsTable) WHERE \(colFolderId) = ? AND \(colName) = ? AND \(colBkId) = ? LIMIT 1"
+                                conflictParams = [fid, res.name, res.bkId]
+                            } else {
+                                conflictSql = "SELECT \(colId), \(colResLastModified) FROM \(resultsTable) WHERE \(colFolderId) IS NULL AND \(colName) = ? AND \(colBkId) = ? LIMIT 1"
+                                conflictParams = [res.name, res.bkId]
+                            }
+
+                            if let row = try db.fetch(query: conflictSql, parameters: conflictParams, mapping: { ($0.int64(at: 0), $0.int64(at: 1)) }).first {
+                                conflictLocalId = row.0
+                                conflictLastMod = row.1
+                            }
                         }
 
                         if conflictLocalId != -1 {
@@ -1096,6 +1122,8 @@ extension ResultsHandler {
                 }
             }
 
+            resolveOrphanResults()
+
             DispatchQueue.main.async {
                 NotificationCenter.default.post(name: .savedResultsTreeDidUpdate, object: nil)
             }
@@ -1104,5 +1132,87 @@ extension ResultsHandler {
             return false
         }
         return true
+    }
+
+    func resolveOrphanFolders() {
+        guard let db else { return }
+        do {
+            try transaction {
+                // Find folders where parentCkRecordId is not null, but parent doesn't match
+                let sql = """
+                SELECT f1.\(colId), f1.\(colName), f1.\(colParentCkRecordId), f2.\(colId) as expected_parent
+                FROM \(foldersTable) f1
+                LEFT JOIN \(foldersTable) f2 ON f1.\(colParentCkRecordId) = f2.\(colCkRecordId)
+                WHERE f1.\(colParentCkRecordId) IS NOT NULL 
+                AND COALESCE(f1.\(colParent), -1) != COALESCE(f2.\(colId), -1)
+                """
+                
+                let orphans = try db.fetch(query: sql) { row -> (id: Int64, name: String, expectedParent: Int64?) in
+                    return (
+                        row.int64(at: 0),
+                        row.string(at: 1) ?? "",
+                        !row.isNull(at: 3) ? row.int64(at: 3) : nil
+                    )
+                }
+                
+                for orphan in orphans {
+                    guard let newParentId = orphan.expectedParent else { continue }
+                    
+                    // Check if unique constraint would be violated
+                    let conflictSql = "SELECT \(colId) FROM \(foldersTable) WHERE \(colParent) = ? AND \(colName) = ? AND \(colId) != ? LIMIT 1"
+                    if let conflictId = try db.fetch(query: conflictSql, parameters: [newParentId, orphan.name, orphan.id], mapping: { $0.int64(at: 0) }).first {
+                        // Merge orphan into existing folder
+                        try exec("UPDATE \(resultsTable) SET \(colFolderId) = ? WHERE \(colFolderId) = ?;", parameters: [conflictId, orphan.id])
+                        try exec("UPDATE \(foldersTable) SET \(colParent) = ? WHERE \(colParent) = ?;", parameters: [conflictId, orphan.id])
+                        try exec("DELETE FROM \(foldersTable) WHERE \(colId) = ?;", parameters: [orphan.id])
+                    } else {
+                        // Safe to reparent
+                        try exec("UPDATE \(foldersTable) SET \(colParent) = ? WHERE \(colId) = ?;", parameters: [newParentId, orphan.id])
+                    }
+                }
+            }
+        } catch {
+            print("ResultsHandler: Failed to resolve orphan folders - \\(error)")
+        }
+    }
+
+    func resolveOrphanResults() {
+        guard let db else { return }
+        do {
+            try transaction {
+                let sql = """
+                SELECT r.\(colId), r.\(colName), r.\(colBkId), f.\(colId) as expected_folder
+                FROM \(resultsTable) r
+                LEFT JOIN \(foldersTable) f ON r.\(colFolderCkRecordId) = f.\(colCkRecordId)
+                WHERE r.\(colFolderCkRecordId) IS NOT NULL
+                AND COALESCE(r.\(colFolderId), -1) != COALESCE(f.\(colId), -1)
+                """
+                
+                let orphans = try db.fetch(query: sql) { row -> (id: Int64, name: String, bkId: Int, expectedFolder: Int64?) in
+                    return (
+                        row.int64(at: 0),
+                        row.string(at: 1) ?? "",
+                        row.int(at: 2),
+                        !row.isNull(at: 3) ? row.int64(at: 3) : nil
+                    )
+                }
+                
+                for orphan in orphans {
+                    guard let newFolderId = orphan.expectedFolder else { continue }
+                    
+                    // Check if unique constraint would be violated
+                    let conflictSql = "SELECT \(colId) FROM \(resultsTable) WHERE \(colFolderId) = ? AND \(colName) = ? AND \(colBkId) = ? AND \(colId) != ? LIMIT 1"
+                    if let _ = try db.fetch(query: conflictSql, parameters: [newFolderId, orphan.name, orphan.bkId, orphan.id], mapping: { $0.int64(at: 0) }).first {
+                        // Conflict: just delete the orphan since it's a leaf node duplicate
+                        try exec("DELETE FROM \(resultsTable) WHERE \(colId) = ?;", parameters: [orphan.id])
+                    } else {
+                        // Safe to reparent
+                        try exec("UPDATE \(resultsTable) SET \(colFolderId) = ? WHERE \(colId) = ?;", parameters: [newFolderId, orphan.id])
+                    }
+                }
+            }
+        } catch {
+            print("ResultsHandler: Failed to resolve orphan results - \\(error)")
+        }
     }
 }

--- a/Source/Managers/Database/ResultsHandler.swift
+++ b/Source/Managers/Database/ResultsHandler.swift
@@ -335,8 +335,10 @@ class ResultsHandler {
     func addPendingSync(ckRecordId: String, operation: String) {
         guard let db else { return }
         if operation == "upload" {
-            let delSql = "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'delete';"
-            try? db.execute(query: delSql, parameters: [ckRecordId])
+            let checkSql = "SELECT COUNT(*) FROM sync_pending WHERE ck_record_id = ? AND operation = 'delete';"
+            if let count = try? db.fetch(query: checkSql, parameters: [ckRecordId], mapping: { $0.int64(at: 0) }).first, count > 0 {
+                return // Delete wins
+            }
         } else if operation == "delete" {
             let delSql = "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';"
             try? db.execute(query: delSql, parameters: [ckRecordId])

--- a/Source/Managers/ViewModels/SettingsViewModel.swift
+++ b/Source/Managers/ViewModels/SettingsViewModel.swift
@@ -123,7 +123,7 @@ final class SettingsViewModel: ObservableObject {
         _ = SettingsActions.selectLibraryFolder(
             showSuccessAlert: false,
             shouldTerminateOnCancel: false,
-            validate: validateDatabaseFolder
+            validate: DatabaseManager.validateDatabaseFolder
         ) { [weak self] success in
             DispatchQueue.main.async {
                 if !success { self?.isBundleMode = true }
@@ -132,54 +132,7 @@ final class SettingsViewModel: ObservableObject {
         }
     }
 
-    private func validateDatabaseFolder(_ url: URL) -> Error? {
-        let fm = FileManager.default
-        let mainFolder = url.appendingPathComponent("Files", isDirectory: true)
 
-        var isDir: ObjCBool = false
-        guard fm.fileExists(atPath: mainFolder.path, isDirectory: &isDir), isDir.boolValue else {
-            return NSError(domain: "Maktabah", code: 1, userInfo: [NSLocalizedDescriptionKey: "Folder 'Files' is missing."])
-        }
-
-        let mainSqlite = mainFolder.appendingPathComponent("main.sqlite")
-        let specialSqlite = mainFolder.appendingPathComponent("special.sqlite")
-
-        guard fm.fileExists(atPath: mainSqlite.path), fm.fileExists(atPath: specialSqlite.path) else {
-            return NSError(domain: "Maktabah", code: 2, userInfo: [NSLocalizedDescriptionKey: "main.sqlite or special.sqlite is missing in the 'Files' folder."])
-        }
-
-        let mainSize = (try? fm.attributesOfItem(atPath: mainSqlite.path)[.size] as? NSNumber)?.int64Value ?? 0
-        let specialSize = (try? fm.attributesOfItem(atPath: specialSqlite.path)[.size] as? NSNumber)?.int64Value ?? 0
-
-        guard mainSize > 0, specialSize > 0 else {
-            return NSError(domain: "Maktabah", code: 3, userInfo: [NSLocalizedDescriptionKey: "Database files are empty."])
-        }
-
-        do {
-            let dbMain = try SQLiteDatabase(path: mainSqlite.path, flags: SQLITE_OPEN_READONLY)
-            let dbSpecial = try SQLiteDatabase(path: specialSqlite.path, flags: SQLITE_OPEN_READONLY)
-
-            let checkTable = { (db: SQLiteDatabase, table: String) throws in
-                var exists = false
-                let query = "SELECT name FROM sqlite_master WHERE type='table' AND name='\(table)'"
-                try db.fetch(query: query) { _ in exists = true }
-                if !exists {
-                    throw NSError(domain: "Maktabah", code: 4, userInfo: [NSLocalizedDescriptionKey: "Table '\(table)' is missing in database."])
-                }
-            }
-
-            try checkTable(dbMain, "0bok")
-            try checkTable(dbMain, "0cat")
-            try checkTable(dbMain, "v")
-
-            try checkTable(dbSpecial, "Auth")
-            try checkTable(dbSpecial, "shorts")
-        } catch {
-            return error
-        }
-
-        return nil
-    }
 
     func chooseAnnotationsFolder(onCompletion: ((Bool) -> Void)? = nil) {
         SettingsActions.chooseAnnotationsAndResultsFolder(resolution: .ask) { [weak self] result in
@@ -217,7 +170,7 @@ final class SettingsViewModel: ObservableObject {
         _ = SettingsActions.selectLibraryFolder(
             showSuccessAlert: true,
             shouldTerminateOnCancel: false,
-            validate: validateDatabaseFolder
+            validate: DatabaseManager.validateDatabaseFolder
         ) { [weak self] success in
             DispatchQueue.main.async {
                 if success { self?.isBundleMode = false }

--- a/Source/iOS/MaktabahApp.swift
+++ b/Source/iOS/MaktabahApp.swift
@@ -35,13 +35,13 @@ struct MaktabahApp: App {
         AppConfig.initializeMode()
         ArabicFont.registerCustomFonts()
         UserFontManager.shared.registerUserFonts()
+        if UserDefaults.standard.data(forKey: AppConfig.annotationsAndResultsFolder) == nil {
+            UserDefaults.standard.register(defaults: [AppConfig.useICloudKey: true])
+        }
         AppConfig.setupAnnotationsAndResults()
         CloudKitSyncManager.shared.initializeOnLaunch()
         // CoreDatabaseBootstrap.run()
         setupGlobalAppearances()
-        if UserDefaults.standard.data(forKey: AppConfig.annotationsAndResultsFolder) == nil {
-            UserDefaults.standard.register(defaults: [AppConfig.useICloudKey: true])
-        }
     }
 
     private func setupGlobalAppearances() {

--- a/Source/iOS/Managers/BootstrapManager.swift
+++ b/Source/iOS/Managers/BootstrapManager.swift
@@ -30,9 +30,15 @@ final class iOSBootstrapManager {
         didPrepare = true
 
         if AppConfig.hasCustomDatabaseFolder() {
-            if let mainPath = AppConfig.mainDatabasePath, FileManager.default.fileExists(atPath: mainPath) {
-                finishSetup()
-                return
+            if let customPath = AppConfig.databaseFilesPath {
+                let customUrl = URL(fileURLWithPath: customPath)
+                let parentUrl = customUrl.deletingLastPathComponent()
+                if DatabaseManager.validateDatabaseFolder(parentUrl) == nil {
+                    finishSetup()
+                    return
+                } else {
+                    AppConfig.resetCustomModeKey()
+                }
             } else {
                 AppConfig.resetCustomModeKey()
             }

--- a/Source/iOS/Views/Annotation/AnnotationViewControllerWrapper.swift
+++ b/Source/iOS/Views/Annotation/AnnotationViewControllerWrapper.swift
@@ -22,6 +22,13 @@ struct AnnotationViewControllerWrapper: UIViewControllerRepresentable {
                 viewModel.deleteAnnotation(id: id)
             }
         }
+        
+        vc.onRefreshRequested = { [weak vc] in
+            CloudKitSyncManager.shared.fetchChanges()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                vc?.endRefreshing()
+            }
+        }
 
         vc.onNeedFullReload = { [weak viewModel] in
             viewModel?.applyFilter()

--- a/Source/iOS/Views/Annotation/iOSAnnotationViewController.swift
+++ b/Source/iOS/Views/Annotation/iOSAnnotationViewController.swift
@@ -13,6 +13,7 @@ class iOSAnnotationViewController: UIViewController {
     var onAnnotationSelected: ((SwiftUIAnnotationNode) -> Void)?
     var onAnnotationDeleted: ((SwiftUIAnnotationNode) -> Void)?
     var onNeedFullReload: (() -> Void)?
+    var onRefreshRequested: (() -> Void)?
 
     // MARK: - Private
 
@@ -307,6 +308,11 @@ class iOSAnnotationViewController: UIViewController {
         collectionView.contentInsetAdjustmentBehavior = .automatic
         collectionView.semanticContentAttribute = .forceLeftToRight
         collectionView.delegate = self
+        
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(handleRefresh), for: .valueChanged)
+        collectionView.refreshControl = refreshControl
+        
         view.addSubview(collectionView)
 
         NSLayoutConstraint.activate([
@@ -467,6 +473,14 @@ class iOSAnnotationViewController: UIViewController {
         item.isGroup
             ? ListLayoutMetrics.separatorTrailingOffset(isRoot: true, indentationLevel: 0)
             : ListLayoutMetrics.defaultPadding * 2
+    }
+    
+    @objc private func handleRefresh() {
+        onRefreshRequested?()
+    }
+    
+    func endRefreshing() {
+        collectionView.refreshControl?.endRefreshing()
     }
 }
 

--- a/Source/iOS/Views/Bootstrap/BootstrapView.swift
+++ b/Source/iOS/Views/Bootstrap/BootstrapView.swift
@@ -40,6 +40,11 @@ struct iOSBootstrapView: View {
             let isCancellable = notification.userInfo?["isCancellable"] as? Bool ?? false
             bootstrapManager.reloadLibrary(isCancellable: isCancellable)
         }
+        .onChange(of: bootstrapManager.isReady) { oldValue, newValue in
+            if newValue {
+                CloudKitSyncManager.shared.fetchChanges()
+            }
+        }
         .overlay {
             if bootstrapManager.showCoreUpdateAlert {
                 ZStack {

--- a/Source/iOS/Views/Search/Bookmark/iOSMoveItemView.swift
+++ b/Source/iOS/Views/Search/Bookmark/iOSMoveItemView.swift
@@ -63,8 +63,7 @@ struct iOSMoveItemView: View {
     private var isRootDisabled: Bool {
         switch target {
         case .folder(let node):
-            return disabledFolderIds.contains(node.id) ||
-                   (viewModel.parentById[node.id] ?? nil) == nil
+            return (viewModel.parentById[node.id] ?? nil) == nil
         case .result(let node):
             return node.parentId == nil
         }

--- a/Source/iOS/Views/Search/Bookmark/iOSSavedResultsView.swift
+++ b/Source/iOS/Views/Search/Bookmark/iOSSavedResultsView.swift
@@ -230,9 +230,14 @@ struct iOSFolderContentList: View {
 
     let viewModel: ResultsViewModel = .shared
 
+    private var currentFolder: FolderNode? {
+        guard let folder else { return nil }
+        return viewModel.folderById[folder.id] ?? folder
+    }
+
     private var children: [FolderNode] {
-        if let folder {
-            return folder.children
+        if let currentFolder {
+            return currentFolder.children
         } else {
             return viewModel.folderRoots
         }

--- a/Source/iOS/Views/Search/Bookmark/iOSSavedResultsView.swift
+++ b/Source/iOS/Views/Search/Bookmark/iOSSavedResultsView.swift
@@ -88,44 +88,44 @@ struct iOSSavedResultsView: View {
                     }
                 }
             }
-            // Sheet & Alerts
-            .sheet(item: $itemToMove) { target in
-                iOSMoveItemView(target: target)
+        }
+        // Sheet & Alerts
+        .sheet(item: $itemToMove) { target in
+            iOSMoveItemView(target: target)
+        }
+        .alert(
+            "Delete Folder",
+            isPresented: Binding(
+                get: { folderToDelete != nil },
+                set: { if !$0 { folderToDelete = nil } }
+            ),
+            presenting: folderToDelete
+        ) { folder in
+            Button("Delete", role: .destructive) {
+                viewModel.deleteFolder(node: folder)
             }
-            .alert(
-                "Delete Folder",
-                isPresented: Binding(
-                    get: { folderToDelete != nil },
-                    set: { if !$0 { folderToDelete = nil } }
-                ),
-                presenting: folderToDelete
-            ) { folder in
-                Button("Delete", role: .destructive) {
-                    viewModel.deleteFolder(node: folder)
+            Button("Cancel", role: .cancel) {}
+        } message: { folder in
+            Text("\"\(folder.name)\" and all its contents will be permanently deleted.")
+        }
+        .alert(
+            itemToRename?.alertTitle ?? "",
+            isPresented: Binding(
+                get: { itemToRename != nil },
+                set: { if !$0 { itemToRename = nil } }
+            )
+        ) {
+            TextField("Name", text: Binding(
+                get: { itemToRename?.draftName ?? "" },
+                set: { itemToRename?.draftName = $0 }
+            ))
+            Button("Save") {
+                if let target = itemToRename {
+                    commitRename(target)
                 }
-                Button("Cancel", role: .cancel) {}
-            } message: { folder in
-                Text("\"\(folder.name)\" and all its contents will be permanently deleted.")
             }
-            .alert(
-                itemToRename?.alertTitle ?? "",
-                isPresented: Binding(
-                    get: { itemToRename != nil },
-                    set: { if !$0 { itemToRename = nil } }
-                )
-            ) {
-                TextField("Name", text: Binding(
-                    get: { itemToRename?.draftName ?? "" },
-                    set: { itemToRename?.draftName = $0 }
-                ))
-                Button("Save") {
-                    if let target = itemToRename {
-                        commitRename(target)
-                    }
-                }
-                .disabled((itemToRename?.draftName ?? "").trimmingCharacters(in: .whitespaces).isEmpty)
-                Button("Cancel", role: .cancel) {}
-            }
+            .disabled((itemToRename?.draftName ?? "").trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Cancel", role: .cancel) {}
         }
         .task {
             await viewModel.getFolders()


### PR DESCRIPTION
### Summary of Changes

#### 1. CloudKit Sync & Conflict Resolution Improvements
- **Orphan Record Preservation**: Prevented orphaned folders and results from jumping to the root level when records arrive out-of-order during CloudKit sync.
- **Queue Optimization**: Converted arrays to `Set` in `retryPendingUploads` for O(1) search lookups and offloaded `applyChangesLocally` execution from main thread bottlenecks.
- **Duplicate Upload Guard**: Reset `InitialUploadDone` flag upon iCloud re-enablement and suppressed backfill upload races to prevent redundant CloudKit network requests.

#### 2. iOS UI State & Navigation Fixes
- **State Detachment Fix**: Resolved an issue in `iOSSavedResultsView` where `NavigationStack` held stale folder instances, ensuring live updates reflect immediately on screen after moving or editing folders.
- **Alert & Sheet Context**: Moved modal sheets and alerts outside the `NavigationStack` context to resolve queued alert presentation issues.
- **Folder Moving Logic**: Corrected root movement validation in `iOSMoveItemView`.

#### 3. UX & Fresh Install Triggers
- **Pull-to-Refresh Annotations**: Added `UIRefreshControl` in `iOSAnnotationViewController` allowing users to manually trigger CloudKit sync.
- **Fresh Install Sync**: Triggered CloudKit change fetches automatically once core database bootstrapping finishes on first launch.