### PR TITLE
perf: optimize SQLite string extraction, ZSTD decoding, and fix notification memory leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-21 - Optimize SQLite String Extraction
+**Pembelajaran:** Penggunaan `String(cString:)` di dalam loop yang mengekstrak teks dari SQLite memicu implicit `strlen` C string yang berakibat pada penurunan performa (O(N)) dan copy data tidak perlu. API SQLite dapat langsung menyediakan panjang bytes via `sqlite3_column_bytes`.
+**Tindakan:** Mengganti penggunaan `String(cString:)` dengan `UnsafeBufferPointer` dan `String(decoding:as:)` setelah memanggil `sqlite3_column_bytes` pada iterasi database (e.g. buildFTS dan proses tabel ZSTD) untuk read zero-copy tanpa double pass.

--- a/Source/Managers/App Config/ReusableFunc.swift
+++ b/Source/Managers/App Config/ReusableFunc.swift
@@ -248,7 +248,7 @@ class ReusableFunc {
                 outputBuffer.removeSubrange(decompressedSize..<outputBuffer.count)
             }
 
-            return String(data: outputBuffer, encoding: .utf8) ?? ""
+            return String(decoding: outputBuffer, as: UTF8.self)
         }
     }
 

--- a/Source/Managers/Database/ArchiveDatabaseTools.swift
+++ b/Source/Managers/Database/ArchiveDatabaseTools.swift
@@ -94,7 +94,9 @@ enum ArchiveDatabaseTools {
 
         while sqlite3_step(selectStmt) == SQLITE_ROW {
             guard let textPtr = sqlite3_column_text(selectStmt, 1) else { continue }
-            let normalized = String(cString: textPtr)
+            let textBytes = sqlite3_column_bytes(selectStmt, 1)
+            let textBuffer = UnsafeBufferPointer(start: textPtr, count: Int(textBytes))
+            let normalized = String(decoding: textBuffer, as: UTF8.self)
                 .replacingOccurrences(of: "\n", with: " ")
                 .normalizeArabic()
             guard !normalized.isEmpty else { continue }

--- a/Source/Managers/Database/BookUpdateManager.swift
+++ b/Source/Managers/Database/BookUpdateManager.swift
@@ -1335,7 +1335,9 @@ final class BookUpdateManager {
                     if column.name.lowercased() == "nass" {
                         if let textPtr = sqlite3_column_text(selectStmt, colIndex)
                         {
-                            let text = String(cString: textPtr)
+                            let bytes = sqlite3_column_bytes(selectStmt, colIndex)
+                            let buffer = UnsafeBufferPointer(start: textPtr, count: Int(bytes))
+                            let text = String(decoding: buffer, as: UTF8.self)
                             if let compressed = ReusableFunc.compressData(text) {
                                 _ = compressed.withUnsafeBytes { bytes in
                                     sqlite3_bind_blob(
@@ -1689,7 +1691,9 @@ final class BookUpdateManager {
         guard let stmt, let textPtr = sqlite3_column_text(stmt, index) else {
             return ""
         }
-        return String(cString: textPtr)
+        let bytes = sqlite3_column_bytes(stmt, index)
+        let buffer = UnsafeBufferPointer(start: textPtr, count: Int(bytes))
+        return String(decoding: buffer, as: UTF8.self)
     }
 }
 

--- a/Source/Reader/IbarotTextVC.swift
+++ b/Source/Reader/IbarotTextVC.swift
@@ -141,8 +141,16 @@ class IbarotTextVC: NSViewController {
         }
     }
 
+    private var observerTokens: [NSObjectProtocol] = []
+
+    deinit {
+        for token in observerTokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
     private func setupNotificationObservers() {
-        NotificationCenter.default.addObserver(
+        observerTokens.append(NotificationCenter.default.addObserver(
             forName: .libraryFolderChanged,
             object: nil,
             queue: .current
@@ -150,9 +158,9 @@ class IbarotTextVC: NSViewController {
             guard let self else { return }
             viewModel.cleanUpState()
             viewModel.tocViewModel.cleanUp()
-        }
+        })
 
-        NotificationCenter.default.addObserver(
+        observerTokens.append(NotificationCenter.default.addObserver(
             forName: .bookIntegrated,
             object: nil,
             queue: .main
@@ -163,9 +171,9 @@ class IbarotTextVC: NSViewController {
                     clearUI()
                 }
             }
-        }
+        })
 
-        NotificationCenter.default.addObserver(
+        observerTokens.append(NotificationCenter.default.addObserver(
             forName: .bookIdMigrated,
             object: nil,
             queue: .main
@@ -183,7 +191,7 @@ class IbarotTextVC: NSViewController {
                     viewModel.currentBook = newBookData
                 }
             }
-        }
+        })
     }
 
     // MARK: - State Accessors

--- a/Source/iOS/Managers/iOSNavigationManager.swift
+++ b/Source/iOS/Managers/iOSNavigationManager.swift
@@ -43,14 +43,21 @@ class iOSNavigationManager {
         setupObservers()
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /* we dont need observer tokens here. as we use @MainActor
+     and cannot remove tokens on deinit method. */
     private func setupObservers() {
         NotificationCenter.default.addObserver(
             forName: .bookIntegrated,
             object: nil,
             queue: .main
-        ) { [weak self] notification in
-            guard let self, let bookId = notification.object as? Int else { return }
-            Task { @MainActor in
+        ) { notification in
+            guard let bookId = notification.object as? Int else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
                 self.handleBookIntegrationChanged(bookId: bookId)
             }
         }
@@ -59,8 +66,8 @@ class iOSNavigationManager {
             forName: .libraryFolderChanged,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
+        ) { _ in
+            Task { @MainActor [weak self] in
                 self?.clearAllTabs()
             }
         }
@@ -70,12 +77,12 @@ class iOSNavigationManager {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            guard let self,
-                  let userInfo = notification.userInfo,
+            guard let userInfo = notification.userInfo,
                   let oldId = userInfo["oldId"] as? Int,
                   let newId = userInfo["newId"] as? Int else { return }
-            Task { @MainActor in
-                self.handleBookIdMigrated(oldId: oldId, newId: newId)
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                handleBookIdMigrated(oldId: oldId, newId: newId)
             }
         }
     }


### PR DESCRIPTION
### Summary of Changes

#### 1. Zero-Copy & Fast String Decoding
- **SQLite String Extraction**: Replaced `String(cString:)` loops with direct `sqlite3_column_bytes` and `UnsafeBufferPointer` UTF-8 decoding (`String(decoding:as:)`) in `ArchiveDatabaseTools` and `BookUpdateManager`. This avoids unnecessary O(N) `strlen` passes on large text columns.
- **ZSTD Decompression**: Replaced `String(data:encoding:)` in `ReusableFunc.decompressData` with direct `String(decoding:as: UTF8.self)` on the output byte buffer.

#### 2. Memory Leak Prevention
- **IbarotTextVC (macOS)**: Stored `NSObjectProtocol` tokens from `NotificationCenter.addObserver` and added explicit removal logic in `deinit`.
- **iOSNavigationManager (iOS)**: Cleaned up closure capture rules to prevent retain cycles in `@MainActor` task blocks when handling system notifications.