### PR TITLE
fix: Reader TOC & Content Loading

### DIFF
--- a/Source/Protocols/Protocols.swift
+++ b/Source/Protocols/Protocols.swift
@@ -42,7 +42,7 @@ protocol SearchableLibrarySidebar: AnyObject {
     func connectSearchField(_ field: DSFSearchField)
 }
 
-// LibraryVC
+/// LibraryVC
 extension LibraryVC: SearchableLibrarySidebar {
     func connectSearchField(_ field: DSFSearchField) {
         guard let searchField else {
@@ -60,7 +60,7 @@ extension LibraryVC: SearchableLibrarySidebar {
     }
 }
 
-// SearchSidebarVC
+/// SearchSidebarVC
 extension SearchSidebarVC: SearchableLibrarySidebar {
     func connectSearchField(_ field: DSFSearchField) {
         guard let searchField else {
@@ -79,7 +79,7 @@ extension SearchSidebarVC: SearchableLibrarySidebar {
     }
 }
 
-// atau buat computed var yang wrap-nya
+/// atau buat computed var yang wrap-nya
 extension RowiSidebarVC: SearchableLibrarySidebar {
     func connectSearchField(_ field: DSFSearchField) {
         guard let searchField else {
@@ -94,4 +94,3 @@ extension RowiSidebarVC: SearchableLibrarySidebar {
     }
 }
 #endif
-

--- a/Source/Protocols/Protocols.swift
+++ b/Source/Protocols/Protocols.swift
@@ -16,9 +16,8 @@ protocol SidebarDelegate: AnyObject {
 }
 
 protocol LibraryDelegate: AnyObject {
-    func didSelectBook(for book: BooksData) async
+    func didSelectBook(for book: BooksData, loadContent: Bool) async
 }
-
 
 protocol ResultsDelegate: AnyObject {
     func didSelect(savedResults: [SavedResultsItem])

--- a/Source/Reader/IbarotTextVC.swift
+++ b/Source/Reader/IbarotTextVC.swift
@@ -217,14 +217,22 @@ class IbarotTextVC: NSViewController {
         return nil
     }
 
-    var currentBook: BooksData? { viewModel.currentBook }
+    var currentBook: BooksData? {
+        viewModel.currentBook
+    }
 
-    var currentPage: Int? { viewModel.currentPage }
+    var currentPage: Int? {
+        viewModel.currentPage
+    }
 
-    var currentPart: Int? { viewModel.currentPart }
+    var currentPart: Int? {
+        viewModel.currentPart
+    }
 
     /// Alias ke viewModel.bookConnection untuk backward compatibility dengan SidebarVC
-    var bookDB: BookConnection { viewModel.bookConnection }
+    var bookDB: BookConnection {
+        viewModel.bookConnection
+    }
 
     var currentRowi: Rowi? {
         get { splitVC?.currentState.currentRowi }
@@ -309,17 +317,16 @@ class IbarotTextVC: NSViewController {
                 WindowController.showPopOver(sender: button, viewController: bookInf)
             } else {
                 bookInf.popOver = false
-                self.presentAsSheet(bookInf)
+                presentAsSheet(bookInf)
             }
         }
     }
 
     @IBAction func copyWith(_ sender: Any? = nil) {
-        let attributedText: NSAttributedString
-        if textView.selectedRange.length > 1 {
-            attributedText = textView.attributedString().attributedSubstring(from: textView.selectedRange())
+        let attributedText: NSAttributedString = if textView.selectedRange.length > 1 {
+            textView.attributedString().attributedSubstring(from: textView.selectedRange())
         } else {
-            attributedText = textView.attributedString()
+            textView.attributedString()
         }
 
         let combined = NSMutableAttributedString(attributedString: attributedText)
@@ -538,7 +545,7 @@ extension IbarotTextVC: ReaderStateComponent {
             state.scrollPosition = scrollView.documentVisibleRect.origin
         }
 
-        if let sidebarVC = sidebarVC {
+        if let sidebarVC {
             state.expandedNodeIDs = collectExpandedNodeIDs()
             state.sidebarScrollPosition = sidebarVC.scrollView.documentVisibleRect.origin
         }
@@ -553,7 +560,8 @@ extension IbarotTextVC: ReaderStateComponent {
         try? viewModel.bookConnection.connect(archive: book.archive)
 
         if AppConfig.isUsingBundleMode,
-           !BookArchiveIntegrator.shared.isBookIntegrated(book) {
+           !BookArchiveIntegrator.shared.isBookIntegrated(book)
+        {
             viewModel.currentBook = nil
             return
         }

--- a/Source/Reader/IbarotTextVC.swift
+++ b/Source/Reader/IbarotTextVC.swift
@@ -137,7 +137,17 @@ class IbarotTextVC: NSViewController {
         }
 
         viewModel.tocViewModel.onTOCLoaded = { [weak self] nodes in
-            self?.sidebarVC?.updateTOC(nodes)
+            guard let self else { return }
+            sidebarVC?.updateTOC(nodes)
+            // Auto-expand TOC ke konten yang sedang aktif begitu TOC selesai di-load di background
+            if viewModel.currentContentId > 0,
+               let bookId = viewModel.currentBook?.id,
+               let content = viewModel.getContent(
+                   bkId: bookId, contentId: viewModel.currentContentId
+               )
+            {
+                handleNavigationToContent(content)
+            }
         }
     }
 
@@ -346,12 +356,12 @@ class IbarotTextVC: NSViewController {
 
     private func handleNavigationToContent(_ content: BookContent) {
         guard let sidebarVC else { return }
-        
+
         if lastSelectedContentIdFromSidebar == content.id {
             lastSelectedContentIdFromSidebar = nil
             return
         }
-        
+
         sidebarVC.enableDelegate = false
         Task {
             if let node = viewModel.tocViewModel.findNode(forContentId: content.id) {
@@ -369,7 +379,7 @@ class IbarotTextVC: NSViewController {
         var expandedIDs: [Int] = []
         func collectExpanded(item: Any?) {
             let childCount = outlineView.numberOfChildren(ofItem: item)
-            for i in 0..<childCount {
+            for i in 0 ..< childCount {
                 let child = outlineView.child(i, ofItem: item)
                 if let node = child as? TOCNode {
                     if outlineView.isItemExpanded(child) {
@@ -476,7 +486,7 @@ extension IbarotTextVC {
             $0.authorDisplayMode = .rowiInfo
         }
         #if DEBUG
-            print("Author mode: display mode (\(String(describing: state.authorDisplayMode)))")
+        print("Author mode: display mode (\(String(describing: state.authorDisplayMode)))")
         #endif
     }
 }
@@ -503,7 +513,7 @@ extension IbarotTextVC: TarjamahBDelegate {
             contentId: tarjamahB.id
         ) else {
             #if DEBUG
-                print("unable to get content from tarjamahB")
+            print("unable to get content from tarjamahB")
             #endif
             return
         }

--- a/Source/Reader/IbarotTextVC.swift
+++ b/Source/Reader/IbarotTextVC.swift
@@ -128,7 +128,7 @@ class IbarotTextVC: NSViewController {
 
         // Bind TOC events
         viewModel.tocViewModel.onTOCLoadingStateChanged = { [weak self] isLoading in
-            guard let self = self, let sidebarView = self.sidebarVC?.view else { return }
+            guard let self, let sidebarView = sidebarVC?.view else { return }
             if isLoading {
                 ReusableFunc.showProgressWindow(sidebarView)
             } else {
@@ -456,9 +456,9 @@ extension IbarotTextVC: SidebarDelegate {
 // MARK: - LibraryDelegate
 
 extension IbarotTextVC: LibraryDelegate {
-    func didSelectBook(for book: BooksData) async {
+    func didSelectBook(for book: BooksData, loadContent: Bool) async {
         if viewModel.currentBook?.id == book.id { return }
-        try? await displayBook(book)
+        try? await displayBook(book, loadContent: loadContent)
     }
 }
 

--- a/Source/Reader/LibraryVC.swift
+++ b/Source/Reader/LibraryVC.swift
@@ -242,7 +242,8 @@ class LibraryVC: NSViewController {
         ReusableFunc.unhideSearchField(
             searchFieldIsHidden: searchFieldIsHidden,
             searchField: searchField,
-            scrollViewTopConstraint: scrollViewTopConstraint)
+            scrollViewTopConstraint: scrollViewTopConstraint
+        )
     }
 }
 

--- a/Source/Reader/LibraryVC.swift
+++ b/Source/Reader/LibraryVC.swift
@@ -252,7 +252,7 @@ extension LibraryVC: LibraryViewDelegate {
             let item = outlineView.item(atRow: row)
             if let book = item as? BooksData {
                 HistoryViewModel.shared.addBookToHistory(book.id)
-                await delegate?.didSelectBook(for: book)
+                await delegate?.didSelectBook(for: book, loadContent: true)
             }
         }
     }

--- a/Source/Search/OptionSearchVC.swift
+++ b/Source/Search/OptionSearchVC.swift
@@ -489,7 +489,7 @@ extension OptionSearchVC: LibraryViewDelegate {
         }
 
         // Penggunaan Task sudah benar di sini, tidak perlu Task.detached lagi
-        await delegate?.didSelectBook(for: bookData)
+        await delegate?.didSelectBook(for: bookData, loadContent: false)
         await itemDelegate?.didSelectResult(
             for: book.bookId,
             highlightText: searchText

--- a/Source/Search/OptionSearchVC.swift
+++ b/Source/Search/OptionSearchVC.swift
@@ -9,7 +9,6 @@ import Cocoa
 import Combine
 
 class OptionSearchVC: NSViewController {
-
     @IBOutlet weak var tableView: NSTableView!
     @IBOutlet weak var progressTable: NSProgressIndicator!
     @IBOutlet weak var progressRows: NSProgressIndicator!
@@ -25,16 +24,14 @@ class OptionSearchVC: NSViewController {
 
     /// Menu Item Copy
     lazy var copyMenuItem: NSMenuItem = {
-       let item = NSMenuItem()
+        let item = NSMenuItem()
         item.title = String(localized: "Copy")
         item.action = #selector(copy(_:))
         item.target = self
         return item
     }()
 
-    lazy var viewModel: SearchViewModel = {
-        .init()
-    }()
+    lazy var viewModel: SearchViewModel = .init()
 
     var results: [SearchResultItem] {
         viewModel.results
@@ -56,6 +53,7 @@ class OptionSearchVC: NSViewController {
     var bkId: String = "" {
         didSet { viewModel.targetBookId = bkId }
     }
+
     var onSelectedItem: ((Int, String) -> Void)?
     var onCleanUp: (() -> Void)?
 
@@ -81,7 +79,7 @@ class OptionSearchVC: NSViewController {
                 cleanUpButton, startButton, stopButton, insertNewResults,
                 displayResults,
             ]
-            btn.forEach { button in
+            for button in btn {
                 button?.borderShape = .capsule
             }
         } else {
@@ -113,7 +111,7 @@ class OptionSearchVC: NSViewController {
                 guard let self else { return }
                 let newCount = viewModel.results.count
                 if newCount > tableView.numberOfRows {
-                    let indexSet = IndexSet(tableView.numberOfRows..<newCount)
+                    let indexSet = IndexSet(tableView.numberOfRows ..< newCount)
                     tableView.insertRows(at: indexSet)
                 }
             }
@@ -199,7 +197,7 @@ class OptionSearchVC: NSViewController {
                 progressRows.doubleValue = progressRows.maxValue
                 let newCount = viewModel.results.count
                 if newCount > prevCount {
-                    tableView.insertRows(at: IndexSet(prevCount..<newCount))
+                    tableView.insertRows(at: IndexSet(prevCount ..< newCount))
                 }
             }
             .store(in: &cancellables)
@@ -240,8 +238,8 @@ class OptionSearchVC: NSViewController {
         tableView.target = self
         ReusableFunc.registerNib(
             tableView: tableView,
-            nibName: .resultNib,  // CellIViewIdentifier.resultNib
-            cellIdentifier: .resultAndOutlineChild  // CellIViewIdentifier.resultAndOutlineChild
+            nibName: .resultNib, // CellIViewIdentifier.resultNib
+            cellIdentifier: .resultAndOutlineChild // CellIViewIdentifier.resultAndOutlineChild
         )
     }
 
@@ -264,7 +262,7 @@ class OptionSearchVC: NSViewController {
         viewModel.clearResults()
         tableView.removeRows(
             at: IndexSet(
-                integersIn: 0..<tableView.numberOfRows
+                integersIn: 0 ..< tableView.numberOfRows
             )
         )
         tableView.sortDescriptors.removeAll()
@@ -324,24 +322,24 @@ class OptionSearchVC: NSViewController {
     }
 
     @IBAction func startSearch(_ sender: Any) {
-            if searchText.isEmpty || (compactConfigured && bkId.isEmpty) { return }
-            ReusableFunc.updateBuiltInRecents(with: searchText, in: searchField)
+        if searchText.isEmpty || (compactConfigured && bkId.isEmpty) { return }
+        ReusableFunc.updateBuiltInRecents(with: searchText, in: searchField)
 
-            let isPaused = viewModel.isPaused
-            let isRunning = viewModel.isSearching
+        let isPaused = viewModel.isPaused
+        let isRunning = viewModel.isSearching
 
-            if !isRunning, !isPaused {
-                setupIndeterminateProgress()
-            }
-
-            startSearchEngine()
-
-            if isPaused {
-                updateStartButton(systemSymbolName: "pause.fill", state: .on)
-            } else {
-                updateStartButton(state: .on)
-            }
+        if !isRunning, !isPaused {
+            setupIndeterminateProgress()
         }
+
+        startSearchEngine()
+
+        if isPaused {
+            updateStartButton(systemSymbolName: "pause.fill", state: .on)
+        } else {
+            updateStartButton(state: .on)
+        }
+    }
 
     @IBAction func stopSearch(_ sender: Any?) {
         viewModel.stopSearch()
@@ -385,10 +383,10 @@ class OptionSearchVC: NSViewController {
 }
 
 // MARK: - NSTableViewDataSource & Delegate
-extension OptionSearchVC: NSTableViewDataSource, NSTableViewDelegate {
 
+extension OptionSearchVC: NSTableViewDataSource, NSTableViewDelegate {
     func numberOfRows(in tableView: NSTableView) -> Int {
-        return results.count
+        results.count
     }
 
     func tableView(
@@ -444,7 +442,7 @@ extension OptionSearchVC: NSTableViewDataSource, NSTableViewDelegate {
         let row = tableView.selectedRow
         guard row >= 0, row < results.count else {
             #if DEBUG
-                print("result out of range")
+            print("result out of range")
             #endif
             return
         }
@@ -458,7 +456,6 @@ extension OptionSearchVC: NSTableViewDataSource, NSTableViewDelegate {
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
         24
     }
-
 }
 
 extension OptionSearchVC: NSSearchFieldDelegate {
@@ -469,7 +466,7 @@ extension OptionSearchVC: NSSearchFieldDelegate {
     ) -> Bool {
         switch commandSelector {
         case #selector(NSResponder.insertNewline(_:)),
-            #selector(NSResponder.insertLineBreak(_:)):
+             #selector(NSResponder.insertLineBreak(_:)):
             startSearch(commandSelector)
             return true
         default: return false
@@ -519,7 +516,7 @@ extension OptionSearchVC: ResultsDelegate {
             onInsert: { [weak self] prev, newCount in
                 guard let self else { return }
                 progressTable.doubleValue += Double(newCount - prev)
-                tableView.insertRows(at: IndexSet(prev..<newCount))
+                tableView.insertRows(at: IndexSet(prev ..< newCount))
             },
             onFinish: { [weak self] in
                 guard let self else { return }
@@ -556,7 +553,6 @@ extension OptionSearchVC: ReaderStateComponent {
         tableView.reloadData()
     }
 }
-
 
 extension OptionSearchVC: NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {


### PR DESCRIPTION
Bug Fixes for Reader TOC & Content Loading

## Description
This Pull Request merges bug fixes for the Reader component from the `fixes` branch into the `main` branch. These changes resolve double content loading issues when selecting search results and fix the Table of Contents (TOC) expansion failure after asynchronous content loading completes.

## Changes Made

### 1. Prevent Double Content Loading
- **Issue:** When selecting a search result, the reader triggered redundant double loading of the initial and target content IDs.
- **Solution:** 
  - Updated the `LibraryDelegate` protocol to support an optional `loadContent` parameter.
  - Adjusted `IbarotTextVC`, `LibraryVC`, and `OptionSearchVC` to prevent duplicate load triggers upon search result selection.

### 2. Auto-Expand TOC for Active Content
- **Issue:** The Table of Contents (TOC) failed to expand to the active content node when a book was opened directly from search results.
- **Solution:**
  - Triggered the TOC node selection inside the `onTOCLoaded` callback for the active content ID in `IbarotTextVC`.
  - Ensures correct TOC expansion after asynchronous loading completes.
