### PR TITLE
Potential fix for code scanning alert: Cleartext logging of sensitive information

### DIFF
--- a/Source/Managers/Database/LibraryDataManager.swift
+++ b/Source/Managers/Database/LibraryDataManager.swift
@@ -707,20 +707,20 @@ class LibraryDataManager {
             }
         }
 
-        // Debug: print author counts
+        // Debug: print author hierarchy status (sanitized; no data values)
         #if DEBUG
             print("=== Author Hierarchy Debug ===")
-            print("Total books in _booksById: \(allBooks.count)")
-            print("Total authors in Auth table: \(authors.count)")
-            print("Author groups (muallif != 0): \(booksByAuthor.count)")
-            print("Books with muallif=0: \(booksWithNoAuthor.count)")
+            print("Author hierarchy rebuild started")
+            print("Author/book grouping computed")
+            print("Author hierarchy integrity check completed")
+            print("Author hierarchy debug summary generated")
 
-            // Show sample of author IDs that have books but not in Auth table
+            // Keep internal check but avoid logging IDs/counts
             let authorIdsInBooks = Set(booksByAuthor.keys)
             let authorIdsInAuthTable = Set(authors.map { $0.id })
             let missingAuthorIds = authorIdsInBooks.subtracting(authorIdsInAuthTable)
             if !missingAuthorIds.isEmpty {
-                print("Author IDs in books but NOT in Auth table: \(missingAuthorIds.prefix(10))")
+                print("Author hierarchy mismatch detected")
             }
         #endif
 

--- a/Source/Managers/Database/LibraryDataManager.swift
+++ b/Source/Managers/Database/LibraryDataManager.swift
@@ -780,9 +780,7 @@ class LibraryDataManager {
         }
 
         #if DEBUG
-            print("Total author categories created: \(authorCategories.count)")
-            print("Total books in author hierarchy: \(authorCategories.reduce(0) { $0 + $1.children.count })")
-            print("=== End Debug ===")
+            print("Author hierarchy build completed.")
         #endif
 
         return authorCategories


### PR DESCRIPTION
Potential fix for [https://github.com/bismillah-100/Maktabah/security/code-scanning/1](https://github.com/bismillah-100/Maktabah/security/code-scanning/1)
Potential fix for [https://github.com/bismillah-100/Maktabah/security/code-scanning/2](https://github.com/bismillah-100/Maktabah/security/code-scanning/2)

General fix: avoid logging values derived from potentially sensitive or untrusted data in cleartext. Either remove such logs, or replace them with static, non-data-bearing messages.

Best fix here (single change for all variants): update the `#if DEBUG` logging block in `buildAuthorHierarchy()` so it no longer interpolates computed counts from runtime data. Keep a static debug marker only. This addresses both alerts at line 783 and related variant(s), without changing application functionality (returned data is unchanged).

Edit location:
- `Source/Managers/Database/LibraryDataManager.swift`
- Region around lines 710–724 (`#if DEBUG` block in `buildAuthorHierarchy()`).
- Region around lines 782–786 (`#if DEBUG` block in `buildAuthorHierarchy()`).

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
