### PR TITLE
refactor: migrate history storage to sqlite and separate database manager

### DIFF
--- a/Maktabah.xcodeproj/project.pbxproj
+++ b/Maktabah.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		240682637A5169A63619E577 /* CloudKitSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3373C7B02164CDBB77BFFF48 /* CloudKitSyncManager.swift */; };
+		2519CB6A1E669FBF7124993E /* HistoryDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */; };
 		4B0139E02EEAFC3000424CFA /* CustomSplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0139DF2EEAFC3000424CFA /* CustomSplitView.swift */; };
 		4B0139E22EEB281C00424CFA /* BookPageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0139E12EEB281C00424CFA /* BookPageCache.swift */; };
 		4B0139E42EEB2FDF00424CFA /* StringInterner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0139E32EEB2FDF00424CFA /* StringInterner.swift */; };
@@ -267,6 +268,8 @@
 		4BFCD84C2F10744800E41F8A /* ScheherazadeNew-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4BFCD84B2F10744800E41F8A /* ScheherazadeNew-Regular.ttf */; };
 		4BFCD84F2F10746600E41F8A /* Lateef-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4BFCD84D2F10746600E41F8A /* Lateef-Regular.ttf */; };
 		4BFCD8502F10746600E41F8A /* Lateef-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4BFCD84E2F10746600E41F8A /* Lateef-Bold.ttf */; };
+		61FB988FFF20432B9CEAB7E2 /* HistoryDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */; };
+		B483563522A5498E6D6452ED /* HistoryDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */; };
 		CA267055B8205DAFE55D7442 /* CloudKitSyncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CCE35AFE445BF8BEF37C5F /* CloudKitSyncable.swift */; };
 		CFAA7B20E067D5BB75E4EB23 /* MaktabahApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C09DE835C53C6EFC0748C3 /* MaktabahApp.swift */; };
 		CFEC4F5ACD6D4ADC1B7C5ECA /* CloudKitSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3373C7B02164CDBB77BFFF48 /* CloudKitSyncManager.swift */; };
@@ -748,6 +751,7 @@
 		F3EB89682FAF72AE00ED75F0 /* SearchResultsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsListView.swift; sourceTree = "<group>"; };
 		F3F2D58F2FE6B2DE006943DC /* AnnotationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationViewModel.swift; sourceTree = "<group>"; };
 		F3FF13692FE757B500E74201 /* TextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStorage.swift; sourceTree = "<group>"; };
+		F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HistoryDatabaseManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -888,12 +892,12 @@
 				F3D46E9A2FD1D45900079FF9 /* CoreUpdateAlert.swift */,
 				4BEC35902F34BA330038FC0F /* DatabaseError.swift */,
 				4B32024D2EDB13C0003B95D1 /* DatabaseManager.swift */,
-				F36D684B2FC5C76D0028F298 /* HistoryViewModel.swift */,
 				4B8C9DD62F69848F0049E4EF /* IntegrationCache.swift */,
 				4B33928A2EE02E710028C706 /* LibraryDataManager.swift */,
 				4B6100EA2EFA769200CCBED6 /* QuranDataManager.swift */,
 				4B5EC2982EE334C600991F39 /* ResultsHandler.swift */,
 				F321672C2FBB2C0D00601DB3 /* SQLiteDatabase.swift */,
+				F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -1390,6 +1394,7 @@
 				F3D02D3C2FE04D580054807F /* Protocols */,
 				F3F2D58F2FE6B2DE006943DC /* AnnotationViewModel.swift */,
 				F35A7AC52FE304E800355E70 /* BookTOCViewModel.swift */,
+				F36D684B2FC5C76D0028F298 /* HistoryViewModel.swift */,
 				F3D02D5C2FE05A650054807F /* LibraryViewModel.swift */,
 				F3D02D602FE0616B0054807F /* NarratorViewModel.swift */,
 				F3D02D412FE04D580054807F /* ReaderViewModel.swift */,
@@ -1746,6 +1751,7 @@
 				CFEC4F5ACD6D4ADC1B7C5ECA /* CloudKitSyncManager.swift in Sources */,
 				CA267055B8205DAFE55D7442 /* CloudKitSyncable.swift in Sources */,
 				DB899712AF55D9ABF944D61F /* NetworkMonitor.swift in Sources */,
+				61FB988FFF20432B9CEAB7E2 /* HistoryDatabaseManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1891,6 +1897,7 @@
 				F321E0252FC7050F00CB37DD /* AnnotationSyncHandler.swift in Sources */,
 				F321E0262FC7050F00CB37DD /* HistorySyncHandler.swift in Sources */,
 				F321E0272FC7050F00CB37DD /* ResultSyncHandler.swift in Sources */,
+				2519CB6A1E669FBF7124993E /* HistoryDatabaseManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2036,6 +2043,7 @@
 				F3D02D612FE0616B0054807F /* NarratorViewModel.swift in Sources */,
 				F3B60E202FC7CC3A00A9EF58 /* iOSBookSearchView.swift in Sources */,
 				240682637A5169A63619E577 /* CloudKitSyncManager.swift in Sources */,
+				B483563522A5498E6D6452ED /* HistoryDatabaseManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Maktabah.xcodeproj/project.pbxproj
+++ b/Maktabah.xcodeproj/project.pbxproj
@@ -892,12 +892,12 @@
 				F3D46E9A2FD1D45900079FF9 /* CoreUpdateAlert.swift */,
 				4BEC35902F34BA330038FC0F /* DatabaseError.swift */,
 				4B32024D2EDB13C0003B95D1 /* DatabaseManager.swift */,
+				F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */,
 				4B8C9DD62F69848F0049E4EF /* IntegrationCache.swift */,
 				4B33928A2EE02E710028C706 /* LibraryDataManager.swift */,
 				4B6100EA2EFA769200CCBED6 /* QuranDataManager.swift */,
 				4B5EC2982EE334C600991F39 /* ResultsHandler.swift */,
 				F321672C2FBB2C0D00601DB3 /* SQLiteDatabase.swift */,
-				F87A6247BC6183CE4E42296D /* HistoryDatabaseManager.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";

--- a/Source/Managers/App Config/AppConfig.swift
+++ b/Source/Managers/App Config/AppConfig.swift
@@ -593,7 +593,7 @@ struct AppConfig {
 
     private static func migrateFiles(from sourceURL: URL, to destURL: URL) {
         let fm = FileManager.default
-        let files = ["Annotations.sqlite", "SearchResults.sqlite"]
+        let files = ["Annotations.sqlite", "SearchResults.sqlite", "History.sqlite"]
         let exts = ["", "-wal", "-shm"]
 
         for file in files {

--- a/Source/Managers/App Config/SettingsActions.swift
+++ b/Source/Managers/App Config/SettingsActions.swift
@@ -359,7 +359,7 @@ enum SettingsActions {
         ResultsHandler.shared.disconnect()
 
         if let oldURL, fm.fileExists(atPath: oldURL.path) {
-            let filesToMove = ["Annotations.sqlite", "SearchResults.sqlite", "Annotations.sqlite-wal", "Annotations.sqlite-shm", "SearchResults.sqlite-wal", "SearchResults.sqlite-shm"]
+            let filesToMove = ["Annotations.sqlite", "SearchResults.sqlite", "History.sqlite", "Annotations.sqlite-wal", "Annotations.sqlite-shm", "SearchResults.sqlite-wal", "SearchResults.sqlite-shm", "History.sqlite-wal", "History.sqlite-shm"]
 
             // Phase 1: Check for collisions
             if resolution == .ask {

--- a/Source/Managers/Database/AnnotationManager/AnnMgr+DB.swift
+++ b/Source/Managers/Database/AnnotationManager/AnnMgr+DB.swift
@@ -101,9 +101,7 @@ extension AnnotationManager {
 
         try backfillCloudKitFieldsIfNeeded { backfilled in
             if !backfilled.isEmpty {
-                DispatchQueue.global(qos: .background).async {
-                    CloudKitSyncManager.shared.upload(annotations: backfilled)
-                }
+                CloudKitSyncManager.shared.upload(annotations: backfilled, debounce: false)
             }
         }
     }

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -110,7 +110,7 @@ final class CloudKitSyncManager {
             let allAnnotations = AnnotationManager.shared.loadAnnotations()
             let toUploadAnn = allAnnotations.filter { annPendingSet.contains($0.ckRecordId ?? "") }
             if !toUploadAnn.isEmpty {
-                upload(annotations: toUploadAnn)
+                upload(annotations: toUploadAnn, debounce: false)
             }
 
             let foundIds = Set(toUploadAnn.compactMap(\.ckRecordId))
@@ -126,7 +126,7 @@ final class CloudKitSyncManager {
             let toUploadResults = allResults.filter { resPendingSet.contains($0.ckRecordId ?? "") }
 
             if !toUploadFolders.isEmpty || !toUploadResults.isEmpty {
-                uploadResultsData(folders: toUploadFolders, results: toUploadResults)
+                uploadResultsData(folders: toUploadFolders, results: toUploadResults, debounce: false)
             }
 
             let foundFolderIds = Set(toUploadFolders.compactMap(\.ckRecordId))
@@ -140,7 +140,7 @@ final class CloudKitSyncManager {
             let allHist = HistoryViewModel.shared.getAllEntries()
             let toUploadHist = allHist.filter { histPendingSet.contains($0.ckRecordId ?? "") }
             if !toUploadHist.isEmpty {
-                uploadHistory(entries: toUploadHist)
+                uploadHistory(entries: toUploadHist, debounce: false)
             }
 
             let foundIds = Set(toUploadHist.compactMap(\.ckRecordId))
@@ -217,7 +217,7 @@ final class CloudKitSyncManager {
 
         if let _ = AnnotationManager.shared.db {
             try? AnnotationManager.shared.backfillCloudKitFieldsIfNeeded { [weak self] backfilled in
-                if !isInitialUpload, !backfilled.isEmpty { self?.upload(annotations: backfilled) }
+                if !isInitialUpload, !backfilled.isEmpty { self?.upload(annotations: backfilled, debounce: false) }
             }
         }
 
@@ -226,7 +226,7 @@ final class CloudKitSyncManager {
         }
 
         HistoryViewModel.shared.backfillCloudKitFieldsIfNeeded { [weak self] backfilled in
-            if !isInitialUpload, !backfilled.isEmpty { self?.uploadHistory(entries: backfilled) }
+            if !isInitialUpload, !backfilled.isEmpty { self?.uploadHistory(entries: backfilled, debounce: false) }
         }
 
         if isInitialUpload {
@@ -247,7 +247,7 @@ final class CloudKitSyncManager {
         for i in stride(from: 0, to: allAnnotations.count, by: batchSize) {
             let batch = Array(allAnnotations[i ..< min(i + batchSize, allAnnotations.count)])
             group.enter()
-            upload(annotations: batch) { result in
+            upload(annotations: batch, debounce: false) { result in
                 if case .failure = result { hasError = true }
                 group.leave()
             }
@@ -257,7 +257,7 @@ final class CloudKitSyncManager {
         for i in stride(from: 0, to: allFolders.count, by: batchSize) {
             let batch = Array(allFolders[i ..< min(i + batchSize, allFolders.count)])
             group.enter()
-            uploadResultsData(folders: batch, results: []) { result in
+            uploadResultsData(folders: batch, results: [], debounce: false) { result in
                 if case .failure = result { hasError = true }
                 group.leave()
             }
@@ -267,7 +267,7 @@ final class CloudKitSyncManager {
         for i in stride(from: 0, to: allResults.count, by: batchSize) {
             let batch = Array(allResults[i ..< min(i + batchSize, allResults.count)])
             group.enter()
-            uploadResultsData(folders: [], results: batch) { result in
+            uploadResultsData(folders: [], results: batch, debounce: false) { result in
                 if case .failure = result { hasError = true }
                 group.leave()
             }
@@ -277,7 +277,7 @@ final class CloudKitSyncManager {
         for i in stride(from: 0, to: allHistory.count, by: batchSize) {
             let batch = Array(allHistory[i ..< min(i + batchSize, allHistory.count)])
             group.enter()
-            uploadHistory(entries: batch) { result in
+            uploadHistory(entries: batch, debounce: false) { result in
                 if case .failure = result { hasError = true }
                 group.leave()
             }
@@ -296,6 +296,7 @@ final class CloudKitSyncManager {
 
     func upload(
         annotations: [Annotation],
+        debounce: Bool = true,
         completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         guard AppConfig.useICloud else { completion?(.success(())); return }
@@ -318,12 +319,17 @@ final class CloudKitSyncManager {
                 annotationDebounceCompletions.append(completion)
             }
 
-            annotationDebounceTask?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.performDebouncedAnnotationUpload()
+            self.annotationDebounceTask?.cancel()
+
+            if debounce {
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.performDebouncedAnnotationUpload()
+                }
+                self.annotationDebounceTask = workItem
+                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
+            } else {
+                self.performDebouncedAnnotationUpload()
             }
-            annotationDebounceTask = workItem
-            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
         }
     }
 
@@ -342,7 +348,9 @@ final class CloudKitSyncManager {
             annotationDebounceCompletions.removeAll()
 
             guard !records.isEmpty else {
-                pendingCompletions.forEach { $0(.success(())) }
+                DispatchQueue.main.async {
+                    pendingCompletions.forEach { $0(.success(())) }
+                }
                 return
             }
 
@@ -357,7 +365,11 @@ final class CloudKitSyncManager {
 
                 group.enter()
                 self.core.upload(records: batch) { [weak self] result in
-                    self?.handleUploadResult(
+                    guard let self = self else {
+                        group.leave()
+                        return
+                    }
+                    self.handleUploadResult(
                         result,
                         pendingIds: ids,
                         target: .annotation,
@@ -383,9 +395,15 @@ final class CloudKitSyncManager {
         }
     }
 
+    private var resultFolderUploadBuffer: [String: SyncFolder] = [:]
+    private var resultUploadBuffer: [String: SyncResult] = [:]
+    private var resultDebounceTask: DispatchWorkItem?
+    private var resultDebounceCompletions: [(Result<Void, Error>) -> Void] = []
+
     func uploadResultsData(
         folders: [SyncFolder],
         results: [SyncResult],
+        debounce: Bool = true,
         completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         guard AppConfig.useICloud else { completion?(.success(())); return }
@@ -400,20 +418,65 @@ final class CloudKitSyncManager {
 
         syncQueue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
+            
+            for folder in folders {
+                if let ckId = folder.ckRecordId {
+                    self.resultFolderUploadBuffer[ckId] = folder
+                }
+            }
+            
+            for result in results {
+                if let ckId = result.ckRecordId {
+                    self.resultUploadBuffer[ckId] = result
+                }
+            }
+
+            if let completion {
+                self.resultDebounceCompletions.append(completion)
+            }
+
+            self.resultDebounceTask?.cancel()
+
+            if debounce {
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.performDebouncedResultUpload()
+                }
+                self.resultDebounceTask = workItem
+                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
+            } else {
+                self.performDebouncedResultUpload()
+            }
+        }
+    }
+
+    private func performDebouncedResultUpload() {
+        syncQueue.async(flags: .barrier) { [weak self] in
+            guard let self else { return }
+
+            let foldersToUpload = Array(resultFolderUploadBuffer.values)
+            let resultsToUpload = Array(resultUploadBuffer.values)
+            resultFolderUploadBuffer.removeAll()
+            resultUploadBuffer.removeAll()
+
             var records: [CKRecord] = []
             records.append(
-                contentsOf: folders.compactMap {
+                contentsOf: foldersToUpload.compactMap {
                     $0.toCKRecord(zoneID: self.core.zoneId)
                 }
             )
             records.append(
-                contentsOf: results.compactMap {
+                contentsOf: resultsToUpload.compactMap {
                     $0.toCKRecord(zoneID: self.core.zoneId)
                 }
             )
 
+            let pendingCompletions = resultDebounceCompletions
+            resultDebounceCompletions.removeAll()
+
             guard !records.isEmpty else {
-                completion?(.success(()))
+                DispatchQueue.main.async {
+                    pendingCompletions.forEach { $0(.success(())) }
+                }
                 return
             }
 
@@ -428,7 +491,11 @@ final class CloudKitSyncManager {
 
                 group.enter()
                 self.core.upload(records: batch) { [weak self] result in
-                    self?.handleUploadResult(
+                    guard let self = self else {
+                        group.leave()
+                        return
+                    }
+                    self.handleUploadResult(
                         result,
                         pendingIds: ids,
                         target: .result,
@@ -446,13 +513,14 @@ final class CloudKitSyncManager {
 
             group.notify(queue: .main) {
                 if let error = lastError {
-                    completion?(.failure(error))
+                    pendingCompletions.forEach { $0(.failure(error)) }
                 } else {
-                    completion?(.success(()))
+                    pendingCompletions.forEach { $0(.success(())) }
                 }
             }
         }
     }
+
 
     private var historyUploadBuffer: [String: ReadingEntry] = [:]
     private var historyDebounceTask: DispatchWorkItem?
@@ -460,6 +528,7 @@ final class CloudKitSyncManager {
 
     func uploadHistory(
         entries: [ReadingEntry],
+        debounce: Bool = true,
         completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         guard AppConfig.useICloud else { completion?(.success(())); return }
@@ -481,12 +550,17 @@ final class CloudKitSyncManager {
                 historyDebounceCompletions.append(completion)
             }
 
-            historyDebounceTask?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.performDebouncedHistoryUpload()
+            self.historyDebounceTask?.cancel()
+
+            if debounce {
+                let workItem = DispatchWorkItem { [weak self] in
+                    self?.performDebouncedHistoryUpload()
+                }
+                self.historyDebounceTask = workItem
+                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
+            } else {
+                self.performDebouncedHistoryUpload()
             }
-            historyDebounceTask = workItem
-            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
         }
     }
 
@@ -505,7 +579,9 @@ final class CloudKitSyncManager {
             historyDebounceCompletions.removeAll()
 
             guard !records.isEmpty else {
-                pendingCompletions.forEach { $0(.success(())) }
+                DispatchQueue.main.async {
+                    pendingCompletions.forEach { $0(.success(())) }
+                }
                 return
             }
 
@@ -520,7 +596,11 @@ final class CloudKitSyncManager {
 
                 group.enter()
                 self.core.upload(records: batch) { [weak self] result in
-                    self?.handleUploadResult(
+                    guard let self = self else {
+                        group.leave()
+                        return
+                    }
+                    self.handleUploadResult(
                         result,
                         pendingIds: ids,
                         target: .history,

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -346,17 +346,39 @@ final class CloudKitSyncManager {
                 return
             }
 
-            let ids = records.map(\.recordID.recordName)
+            let batchSize = 300
+            let group = DispatchGroup()
+            let errorLock = NSLock()
+            var lastError: Error?
 
-            core.upload(records: records) { [weak self] result in
-                self?.handleUploadResult(
-                    result,
-                    pendingIds: ids,
-                    target: .annotation,
-                    completion: { res in
-                        pendingCompletions.forEach { $0(res) }
-                    }
-                )
+            for i in stride(from: 0, to: records.count, by: batchSize) {
+                let batch = Array(records[i ..< min(i + batchSize, records.count)])
+                let ids = batch.map(\.recordID.recordName)
+
+                group.enter()
+                self.core.upload(records: batch) { [weak self] result in
+                    self?.handleUploadResult(
+                        result,
+                        pendingIds: ids,
+                        target: .annotation,
+                        completion: { res in
+                            if case let .failure(err) = res {
+                                errorLock.lock()
+                                lastError = err
+                                errorLock.unlock()
+                            }
+                            group.leave()
+                        }
+                    )
+                }
+            }
+
+            group.notify(queue: .main) {
+                if let error = lastError {
+                    pendingCompletions.forEach { $0(.failure(error)) }
+                } else {
+                    pendingCompletions.forEach { $0(.success(())) }
+                }
             }
         }
     }
@@ -395,18 +417,46 @@ final class CloudKitSyncManager {
                 return
             }
 
-            let ids = records.map(\.recordID.recordName)
+            let batchSize = 300
+            let group = DispatchGroup()
+            let errorLock = NSLock()
+            var lastError: Error?
 
-            core.upload(records: records) { [weak self] result in
-                self?.handleUploadResult(
-                    result,
-                    pendingIds: ids,
-                    target: .result,
-                    completion: completion
-                )
+            for i in stride(from: 0, to: records.count, by: batchSize) {
+                let batch = Array(records[i ..< min(i + batchSize, records.count)])
+                let ids = batch.map(\.recordID.recordName)
+
+                group.enter()
+                self.core.upload(records: batch) { [weak self] result in
+                    self?.handleUploadResult(
+                        result,
+                        pendingIds: ids,
+                        target: .result,
+                        completion: { res in
+                            if case let .failure(err) = res {
+                                errorLock.lock()
+                                lastError = err
+                                errorLock.unlock()
+                            }
+                            group.leave()
+                        }
+                    )
+                }
+            }
+
+            group.notify(queue: .main) {
+                if let error = lastError {
+                    completion?(.failure(error))
+                } else {
+                    completion?(.success(()))
+                }
             }
         }
     }
+
+    private var historyUploadBuffer: [String: ReadingEntry] = [:]
+    private var historyDebounceTask: DispatchWorkItem?
+    private var historyDebounceCompletions: [(Result<Void, Error>) -> Void] = []
 
     func uploadHistory(
         entries: [ReadingEntry],
@@ -421,21 +471,77 @@ final class CloudKitSyncManager {
 
         syncQueue.async(flags: .barrier) { [weak self] in
             guard let self else { return }
-            let records = entries.compactMap { $0.toCKRecord(zoneID: self.core.zoneId) }
+            for entry in entries {
+                if let ckId = entry.ckRecordId {
+                    historyUploadBuffer[ckId] = entry
+                }
+            }
+
+            if let completion {
+                historyDebounceCompletions.append(completion)
+            }
+
+            historyDebounceTask?.cancel()
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.performDebouncedHistoryUpload()
+            }
+            historyDebounceTask = workItem
+            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 2.0, execute: workItem)
+        }
+    }
+
+    private func performDebouncedHistoryUpload() {
+        syncQueue.async(flags: .barrier) { [weak self] in
+            guard let self else { return }
+
+            let entriesToUpload = Array(historyUploadBuffer.values)
+            historyUploadBuffer.removeAll()
+
+            let records = entriesToUpload.compactMap {
+                $0.toCKRecord(zoneID: self.core.zoneId)
+            }
+
+            let pendingCompletions = historyDebounceCompletions
+            historyDebounceCompletions.removeAll()
+
             guard !records.isEmpty else {
-                completion?(.success(()))
+                pendingCompletions.forEach { $0(.success(())) }
                 return
             }
 
-            let ids = records.map(\.recordID.recordName)
+            let batchSize = 300
+            let group = DispatchGroup()
+            let errorLock = NSLock()
+            var lastError: Error?
 
-            core.upload(records: records) { [weak self] result in
-                self?.handleUploadResult(
-                    result,
-                    pendingIds: ids,
-                    target: .history,
-                    completion: completion
-                )
+            for i in stride(from: 0, to: records.count, by: batchSize) {
+                let batch = Array(records[i ..< min(i + batchSize, records.count)])
+                let ids = batch.map(\.recordID.recordName)
+
+                group.enter()
+                self.core.upload(records: batch) { [weak self] result in
+                    self?.handleUploadResult(
+                        result,
+                        pendingIds: ids,
+                        target: .history,
+                        completion: { res in
+                            if case let .failure(err) = res {
+                                errorLock.lock()
+                                lastError = err
+                                errorLock.unlock()
+                            }
+                            group.leave()
+                        }
+                    )
+                }
+            }
+
+            group.notify(queue: .main) {
+                if let error = lastError {
+                    pendingCompletions.forEach { $0(.failure(error)) }
+                } else {
+                    pendingCompletions.forEach { $0(.success(())) }
+                }
             }
         }
     }
@@ -469,31 +575,38 @@ final class CloudKitSyncManager {
 
         let recordIds = ckRecordIds.map { CKRecord.ID(recordName: $0, zoneID: core.zoneId) }
 
-        core.delete(recordIds: recordIds) { [weak self] result in
-            switch result {
-            case .success:
-                self?.removePendingDeletes(ckRecordIds)
-            case let .failure(error):
-                if let ckError = error as? CKError, ckError.code == .partialFailure,
-                   let partialErrors = ckError.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID: Error] {
-                    let failedRecordNames = Set(partialErrors.keys.map(\.recordName))
-                    var idsToRemove = ckRecordIds.filter { !failedRecordNames.contains($0) }
-                    for (recordID, itemError) in partialErrors {
-                        if let itemCKError = itemError as? CKError {
-                            if itemCKError.code == .unknownItem || itemCKError.code == .serverRecordChanged {
-                                idsToRemove.append(recordID.recordName)
+        let batchSize = 300
+
+        for i in stride(from: 0, to: recordIds.count, by: batchSize) {
+            let batch = Array(recordIds[i ..< min(i + batchSize, recordIds.count)])
+            let batchStrIds = batch.map(\.recordName)
+
+            self.core.delete(recordIds: batch) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.removePendingDeletes(batchStrIds)
+                case let .failure(error):
+                    if let ckError = error as? CKError, ckError.code == .partialFailure,
+                       let partialErrors = ckError.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID: Error] {
+                        let failedRecordNames = Set(partialErrors.keys.map(\.recordName))
+                        var idsToRemove = batchStrIds.filter { !failedRecordNames.contains($0) }
+                        for (recordID, itemError) in partialErrors {
+                            if let itemCKError = itemError as? CKError {
+                                if itemCKError.code == .unknownItem || itemCKError.code == .serverRecordChanged {
+                                    idsToRemove.append(recordID.recordName)
+                                }
                             }
                         }
+                        if !idsToRemove.isEmpty {
+                            self?.removePendingDeletes(idsToRemove)
+                        }
+                    } else if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
+                        self?.removePendingDeletes(batchStrIds)
+                    } else if let ckError = error as? CKError, ckError.code == .unknownItem {
+                        self?.removePendingDeletes(batchStrIds)
                     }
-                    if !idsToRemove.isEmpty {
-                        self?.removePendingDeletes(idsToRemove)
-                    }
-                } else if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
-                    self?.removePendingDeletes(ckRecordIds)
-                } else if let ckError = error as? CKError, ckError.code == .unknownItem {
-                    self?.removePendingDeletes(ckRecordIds)
+                    self?.handleCloudKitError(error, operationType: .delete)
                 }
-                self?.handleCloudKitError(error, operationType: .delete)
             }
         }
     }
@@ -699,12 +812,15 @@ final class CloudKitSyncManager {
 
                 if !conflicts.isEmpty {
                     let group = DispatchGroup()
-                    var lastError: Error?
+                    let errorLock = NSLock()
+            var lastError: Error?
 
                     for conflict in conflicts {
                         group.enter()
                         resolveServerRecordConflict(ckError: conflict) { result in
-                            if case let .failure(err) = result { lastError = err }
+                            if case let .failure(err) = result { errorLock.lock()
+                                lastError = err
+                                errorLock.unlock() }
                             group.leave()
                         }
                     }

--- a/Source/Managers/Database/CloudKitSyncManager.swift
+++ b/Source/Managers/Database/CloudKitSyncManager.swift
@@ -63,7 +63,7 @@ final class CloudKitSyncManager {
             case .result:
                 ResultsHandler.shared.addPendingSync(ckRecordId: id, operation: "upload")
             case .history:
-                HistoryViewModel.shared.addPendingSync(ckRecordId: id, operation: "upload")
+                HistoryDatabaseManager.shared.addPendingSync(ckRecordId: id, operation: "upload")
             }
         }
     }
@@ -71,7 +71,7 @@ final class CloudKitSyncManager {
     private func removePendingUploads(_ ids: [String]) {
         AnnotationManager.shared.removePendingSync(ckRecordIds: ids)
         ResultsHandler.shared.removePendingSync(ckRecordIds: ids)
-        HistoryViewModel.shared.removePendingSync(ckRecordIds: ids)
+        HistoryDatabaseManager.shared.removePendingSync(ckRecordIds: ids)
     }
 
     private func addPendingDeletes(_ ids: [String], target: SyncTarget) {
@@ -82,7 +82,7 @@ final class CloudKitSyncManager {
             case .result:
                 ResultsHandler.shared.addPendingSync(ckRecordId: id, operation: "delete")
             case .history:
-                HistoryViewModel.shared.addPendingSync(ckRecordId: id, operation: "delete")
+                HistoryDatabaseManager.shared.addPendingSync(ckRecordId: id, operation: "delete")
             }
         }
     }
@@ -90,7 +90,7 @@ final class CloudKitSyncManager {
     private func removePendingDeletes(_ ids: [String]) {
         AnnotationManager.shared.removePendingSync(ckRecordIds: ids)
         ResultsHandler.shared.removePendingSync(ckRecordIds: ids)
-        HistoryViewModel.shared.removePendingSync(ckRecordIds: ids)
+        HistoryDatabaseManager.shared.removePendingSync(ckRecordIds: ids)
     }
 
     // MARK: - Retry Logic
@@ -98,7 +98,7 @@ final class CloudKitSyncManager {
     private func retryPendingUploads() {
         let annPending = AnnotationManager.shared.fetchPendingSync(operation: "upload")
         let resPending = ResultsHandler.shared.fetchPendingSync(operation: "upload")
-        let histPending = HistoryViewModel.shared.fetchPendingSync(operation: "upload")
+        let histPending = HistoryDatabaseManager.shared.fetchPendingSync(operation: "upload")
 
         guard !annPending.isEmpty || !resPending.isEmpty || !histPending.isEmpty else { return }
 
@@ -152,14 +152,14 @@ final class CloudKitSyncManager {
             removePendingUploads(orphans)
             AnnotationManager.shared.removePendingSync(ckRecordIds: orphans)
             ResultsHandler.shared.removePendingSync(ckRecordIds: orphans)
-            HistoryViewModel.shared.removePendingSync(ckRecordIds: orphans)
+            HistoryDatabaseManager.shared.removePendingSync(ckRecordIds: orphans)
         }
     }
 
     private func retryPendingDeletes() {
         let pending = AnnotationManager.shared.fetchPendingSync(operation: "delete") +
             ResultsHandler.shared.fetchPendingSync(operation: "delete") +
-            HistoryViewModel.shared.fetchPendingSync(operation: "delete")
+            HistoryDatabaseManager.shared.fetchPendingSync(operation: "delete")
 
         guard !pending.isEmpty else { return }
         delete(ckRecordIds: pending, trackPending: false)

--- a/Source/Managers/Database/HistoryDatabaseManager.swift
+++ b/Source/Managers/Database/HistoryDatabaseManager.swift
@@ -129,8 +129,51 @@ class HistoryDatabaseManager {
         try? _db?.execute(query: sql, parameters: params)
     }
 
+    func upsertEntries(_ entries: [ReadingEntry]) {
+        guard let _db, !entries.isEmpty else { return }
+        let chunkSize = 50 // SQLite max params is 999. We have 8 params per entry. 50 * 8 = 400.
+        
+        for i in stride(from: 0, to: entries.count, by: chunkSize) {
+            let chunk = Array(entries[i..<min(i + chunkSize, entries.count)])
+            let placeholders = chunk.map { _ in "(?, ?, ?, ?, ?, ?, ?, ?)" }.joined(separator: ",")
+            let sql = """
+            INSERT OR REPLACE INTO reading_entries
+            (book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id)
+            VALUES \(placeholders);
+            """
+            
+            var params = [Any]()
+            for entry in chunk {
+                params.append(contentsOf: [
+                    entry.bookId,
+                    entry.lastContentId as Any? ?? NSNull(),
+                    entry.lastOpenedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+                    entry.favoritedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+                    entry.positionUpdatedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+                    entry.updatedAt.timeIntervalSince1970,
+                    entry.isFavorite ? 1 : 0,
+                    entry.ckRecordId as Any? ?? NSNull()
+                ])
+            }
+            try? _db.execute(query: sql, parameters: params)
+        }
+    }
+
     func deleteEntry(bookId: Int) {
         try? exec("DELETE FROM reading_entries WHERE book_id = ?;", parameters: [bookId])
+    }
+
+    func deleteEntries(bookIds: [Int]) {
+        guard let _db, !bookIds.isEmpty else { return }
+        let chunkSize = 500
+        for i in stride(from: 0, to: bookIds.count, by: chunkSize) {
+            let chunk = Array(bookIds[i..<min(i + chunkSize, bookIds.count)])
+            let placeholders = chunk.map { _ in "?" }.joined(separator: ",")
+            try? _db.execute(
+                query: "DELETE FROM reading_entries WHERE book_id IN (\(placeholders));",
+                parameters: chunk
+            )
+        }
     }
 
     func saveHistoryOrder(_ order: [Int]) {
@@ -246,28 +289,42 @@ class HistoryDatabaseManager {
 
         // Migrate pending sync
         if let upData = UserDefaults.standard.data(forKey: legacyPendingUploadsKey),
-           let upList = try? JSONDecoder().decode([String].self, from: upData)
+           let upList = try? JSONDecoder().decode([String].self, from: upData), !upList.isEmpty
         {
             let now = Int64(Date().timeIntervalSince1970)
             try? transaction {
-                for ckId in upList {
-                    try? _db.execute(
-                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
-                        parameters: [ckId, now]
+                let chunkSize = 300 // 3 params per entry (3 * 300 = 900)
+                for i in stride(from: 0, to: upList.count, by: chunkSize) {
+                    let chunk = Array(upList[i..<min(i + chunkSize, upList.count)])
+                    let placeholders = chunk.map { _ in "(?, 'upload', ?)" }.joined(separator: ",")
+                    var params = [Any]()
+                    for ckId in chunk {
+                        params.append(contentsOf: [ckId, now])
+                    }
+                    try _db.execute(
+                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES \(placeholders);",
+                        parameters: params
                     )
                 }
             }
         }
 
         if let delData = UserDefaults.standard.data(forKey: legacyPendingDeletesKey),
-           let delList = try? JSONDecoder().decode([String].self, from: delData)
+           let delList = try? JSONDecoder().decode([String].self, from: delData), !delList.isEmpty
         {
             let now = Int64(Date().timeIntervalSince1970)
             try? transaction {
-                for ckId in delList {
-                    try? _db.execute(
-                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
-                        parameters: [ckId, now]
+                let chunkSize = 300 // 3 params per entry
+                for i in stride(from: 0, to: delList.count, by: chunkSize) {
+                    let chunk = Array(delList[i..<min(i + chunkSize, delList.count)])
+                    let placeholders = chunk.map { _ in "(?, 'delete', ?)" }.joined(separator: ",")
+                    var params = [Any]()
+                    for ckId in chunk {
+                        params.append(contentsOf: [ckId, now])
+                    }
+                    try _db.execute(
+                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES \(placeholders);",
+                        parameters: params
                     )
                 }
             }

--- a/Source/Managers/Database/HistoryDatabaseManager.swift
+++ b/Source/Managers/Database/HistoryDatabaseManager.swift
@@ -1,0 +1,284 @@
+//
+//  HistoryDatabaseManager.swift
+//  Maktabah
+//
+//  Created by MacBook on 05/12/25.
+//
+
+import Foundation
+
+class HistoryDatabaseManager {
+    static let shared = HistoryDatabaseManager()
+
+    private var _db: SQLiteDatabase?
+
+    /// Legacy UserDefaults keys — used only for migration
+    private let legacyStorageKey = "CloudReadingEntries"
+    private let legacyPendingUploadsKey = "HistoryPendingUploads"
+    private let legacyPendingDeletesKey = "HistoryPendingDeletes"
+    private let migrationFlag = "HistoryVM_SQLiteMigrated"
+
+    func setupDatabase() {
+        guard let folderURL = AppConfig.folder(for: AppConfig.annotationsAndResultsFolder) else {
+            #if DEBUG
+            print("HistoryDatabaseManager: No folder URL available for History database")
+            #endif
+            return
+        }
+
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: folderURL.path) {
+            try? fm.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        }
+
+        let url = folderURL.appendingPathComponent("History.sqlite")
+
+        do {
+            _db = try SQLiteDatabase(path: url.path)
+            enableWALMode()
+            try createTables()
+        } catch {
+            #if DEBUG
+            print("HistoryDatabaseManager: Failed to setup database: \(error)")
+            #endif
+        }
+    }
+
+    private func enableWALMode() {
+        guard let _db else { return }
+        do {
+            let mode = try _db.fetch(query: "PRAGMA journal_mode = WAL;") { row in
+                row.string(at: 0) ?? ""
+            }.first
+
+            #if DEBUG
+            if mode?.lowercased() != "wal" {
+                print("HistoryDatabaseManager: failed to enable WAL mode, current: \(mode ?? "unknown")")
+            }
+            #endif
+        } catch {
+            #if DEBUG
+            print("HistoryDatabaseManager: error enabling WAL mode: \(error)")
+            #endif
+        }
+    }
+
+    private func createTables() throws {
+        try exec("""
+        CREATE TABLE IF NOT EXISTS reading_entries (
+            book_id INTEGER PRIMARY KEY,
+            last_content_id INTEGER,
+            last_opened_at REAL,
+            favorited_at REAL,
+            position_updated_at REAL,
+            updated_at REAL NOT NULL,
+            is_favorite INTEGER NOT NULL DEFAULT 0,
+            ck_record_id TEXT
+        );
+        """)
+
+        try exec("""
+        CREATE TABLE IF NOT EXISTS history_order (
+            position INTEGER PRIMARY KEY,
+            book_id INTEGER NOT NULL
+        );
+        """)
+
+        try exec("""
+        CREATE TABLE IF NOT EXISTS sync_pending (
+            ck_record_id TEXT PRIMARY KEY,
+            operation TEXT NOT NULL CHECK(operation IN ('upload', 'delete')),
+            queued_at INTEGER NOT NULL
+        );
+        """)
+
+        try exec("CREATE INDEX IF NOT EXISTS idx_re_favorite ON reading_entries (is_favorite, favorited_at);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_sync_pending_op ON sync_pending (operation, queued_at);")
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func exec(_ sql: String, parameters: [Any] = []) throws {
+        guard let _db else { return }
+        try _db.execute(query: sql, parameters: parameters)
+    }
+
+    private func transaction(_ block: () throws -> Void) throws {
+        guard let _db else { return }
+        try _db.transaction(block)
+    }
+
+    // MARK: - Core CRUD
+
+    func upsertEntry(_ entry: ReadingEntry) {
+        let sql = """
+        INSERT OR REPLACE INTO reading_entries
+        (book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+        """
+        let params: [Any] = [
+            entry.bookId,
+            entry.lastContentId as Any? ?? NSNull(),
+            entry.lastOpenedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.favoritedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.positionUpdatedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.updatedAt.timeIntervalSince1970,
+            entry.isFavorite ? 1 : 0,
+            entry.ckRecordId as Any? ?? NSNull(),
+        ]
+        try? _db?.execute(query: sql, parameters: params)
+    }
+
+    func deleteEntry(bookId: Int) {
+        try? exec("DELETE FROM reading_entries WHERE book_id = ?;", parameters: [bookId])
+    }
+
+    func saveHistoryOrder(_ order: [Int]) {
+        try? transaction {
+            try exec("DELETE FROM history_order;")
+            for (position, bookId) in order.enumerated() {
+                try exec("INSERT INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
+            }
+        }
+    }
+
+    // MARK: - Load from Database
+
+    func loadFromDatabase() -> (entries: [ReadingEntry], historyOrder: [Int]) {
+        guard let _db else { return ([], []) }
+
+        let entries = (try? _db.fetch(query: "SELECT book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id FROM reading_entries;") { row -> ReadingEntry in
+            ReadingEntry(
+                bookId: row.int(at: 0),
+                lastContentId: row.isNull(at: 1) ? nil : row.int(at: 1),
+                lastOpenedAt: row.isNull(at: 2) ? nil : Date(timeIntervalSince1970: row.double(at: 2)),
+                favoritedAt: row.isNull(at: 3) ? nil : Date(timeIntervalSince1970: row.double(at: 3)),
+                positionUpdatedAt: row.isNull(at: 4) ? nil : Date(timeIntervalSince1970: row.double(at: 4)),
+                updatedAt: Date(timeIntervalSince1970: row.double(at: 5)),
+                isFavorite: row.int(at: 6) != 0,
+                ckRecordId: row.string(at: 7)
+            )
+        }) ?? []
+
+        let order = (try? _db.fetch(query: "SELECT book_id FROM history_order ORDER BY position;") { row -> Int in
+            row.int(at: 0)
+        }) ?? []
+
+        return (entries, order)
+    }
+
+    // MARK: - Pending Sync (SQLite)
+
+    func addPendingSync(ckRecordId: String, operation: String) {
+        guard let _db else { return }
+        do {
+            if operation == "upload" {
+                let count = try _db.fetch(
+                    query: "SELECT COUNT(*) FROM sync_pending WHERE ck_record_id = ? AND operation = 'delete';",
+                    parameters: [ckRecordId]
+                ) { $0.int64(at: 0) }.first ?? 0
+                if count > 0 { return } // Delete wins
+            } else if operation == "delete" {
+                try _db.execute(
+                    query: "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';",
+                    parameters: [ckRecordId]
+                )
+            }
+            try _db.execute(
+                query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, ?, ?);",
+                parameters: [ckRecordId, operation, Int64(Date().timeIntervalSince1970)]
+            )
+        } catch {
+            #if DEBUG
+            print("HistoryDatabaseManager: addPendingSync error: \(error)")
+            #endif
+        }
+    }
+
+    func removePendingSync(ckRecordIds: [String]) {
+        guard let _db, !ckRecordIds.isEmpty else { return }
+        let placeholders = ckRecordIds.map { _ in "?" }.joined(separator: ",")
+        try? _db.execute(
+            query: "DELETE FROM sync_pending WHERE ck_record_id IN (\(placeholders));",
+            parameters: ckRecordIds
+        )
+    }
+
+    func fetchPendingSync(operation: String) -> [String] {
+        guard let _db else { return [] }
+        return (try? _db.fetch(
+            query: "SELECT ck_record_id FROM sync_pending WHERE operation = ? ORDER BY queued_at ASC;",
+            parameters: [operation]
+        ) { $0.string(at: 0) ?? "" }) ?? []
+    }
+
+    // MARK: - Migration: UserDefaults → SQLite
+
+    func migrateFromUserDefaultsIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: migrationFlag) else { return }
+        guard let _db else { return }
+
+        // Migrate main entries
+        if let data = UserDefaults.standard.data(forKey: legacyStorageKey),
+           let stored = try? JSONDecoder().decode(StoredReadingEntries.self, from: data)
+        {
+            do {
+                try _db.transaction {
+                    for entry in stored.entries {
+                        upsertEntry(entry)
+                    }
+                    // Preserve exact history order
+                    for (position, bookId) in stored.historyOrder.enumerated() {
+                        try exec("INSERT OR REPLACE INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
+                    }
+                }
+            } catch {
+                #if DEBUG
+                print("HistoryDatabaseManager: Migration failed: \(error)")
+                #endif
+                return // Don't mark as migrated if failed
+            }
+        }
+
+        // Migrate pending sync
+        if let upData = UserDefaults.standard.data(forKey: legacyPendingUploadsKey),
+           let upList = try? JSONDecoder().decode([String].self, from: upData)
+        {
+            let now = Int64(Date().timeIntervalSince1970)
+            for ckId in upList {
+                try? _db.execute(
+                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
+                    parameters: [ckId, now]
+                )
+            }
+        }
+
+        if let delData = UserDefaults.standard.data(forKey: legacyPendingDeletesKey),
+           let delList = try? JSONDecoder().decode([String].self, from: delData)
+        {
+            let now = Int64(Date().timeIntervalSince1970)
+            for ckId in delList {
+                try? _db.execute(
+                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
+                    parameters: [ckId, now]
+                )
+            }
+        }
+
+        // Mark migrated and delete old UserDefaults data
+        UserDefaults.standard.set(true, forKey: migrationFlag)
+        UserDefaults.standard.removeObject(forKey: legacyStorageKey)
+        UserDefaults.standard.removeObject(forKey: legacyPendingUploadsKey)
+        UserDefaults.standard.removeObject(forKey: legacyPendingDeletesKey)
+
+        #if DEBUG
+        print("HistoryDatabaseManager: Successfully migrated from UserDefaults to SQLite")
+        #endif
+    }
+}
+
+/// Legacy struct — used only for migration from UserDefaults
+private struct StoredReadingEntries: Codable {
+    let historyOrder: [Int]
+    let entries: [ReadingEntry]
+}

--- a/Source/Managers/Database/HistoryDatabaseManager.swift
+++ b/Source/Managers/Database/HistoryDatabaseManager.swift
@@ -103,7 +103,7 @@ class HistoryDatabaseManager {
         try _db.execute(query: sql, parameters: parameters)
     }
 
-    private func transaction(_ block: () throws -> Void) throws {
+    func transaction(_ block: () throws -> Void) throws {
         guard let _db else { return }
         try _db.transaction(block)
     }
@@ -197,11 +197,15 @@ class HistoryDatabaseManager {
 
     func removePendingSync(ckRecordIds: [String]) {
         guard let _db, !ckRecordIds.isEmpty else { return }
-        let placeholders = ckRecordIds.map { _ in "?" }.joined(separator: ",")
-        try? _db.execute(
-            query: "DELETE FROM sync_pending WHERE ck_record_id IN (\(placeholders));",
-            parameters: ckRecordIds
-        )
+        let chunkSize = 500
+        for i in stride(from: 0, to: ckRecordIds.count, by: chunkSize) {
+            let chunk = Array(ckRecordIds[i..<min(i + chunkSize, ckRecordIds.count)])
+            let placeholders = chunk.map { _ in "?" }.joined(separator: ",")
+            try? _db.execute(
+                query: "DELETE FROM sync_pending WHERE ck_record_id IN (\(placeholders));",
+                parameters: chunk
+            )
+        }
     }
 
     func fetchPendingSync(operation: String) -> [String] {
@@ -245,11 +249,13 @@ class HistoryDatabaseManager {
            let upList = try? JSONDecoder().decode([String].self, from: upData)
         {
             let now = Int64(Date().timeIntervalSince1970)
-            for ckId in upList {
-                try? _db.execute(
-                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
-                    parameters: [ckId, now]
-                )
+            try? transaction {
+                for ckId in upList {
+                    try? _db.execute(
+                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
+                        parameters: [ckId, now]
+                    )
+                }
             }
         }
 
@@ -257,11 +263,13 @@ class HistoryDatabaseManager {
            let delList = try? JSONDecoder().decode([String].self, from: delData)
         {
             let now = Int64(Date().timeIntervalSince1970)
-            for ckId in delList {
-                try? _db.execute(
-                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
-                    parameters: [ckId, now]
-                )
+            try? transaction {
+                for ckId in delList {
+                    try? _db.execute(
+                        query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
+                        parameters: [ckId, now]
+                    )
+                }
             }
         }
 

--- a/Source/Managers/Database/HistoryDatabaseManager.swift
+++ b/Source/Managers/Database/HistoryDatabaseManager.swift
@@ -129,7 +129,7 @@ class HistoryDatabaseManager {
         try? _db?.execute(query: sql, parameters: params)
     }
 
-    func upsertEntries(_ entries: [ReadingEntry]) {
+    func upsertEntries(_ entries: [ReadingEntry]) throws {
         guard let _db, !entries.isEmpty else { return }
         let chunkSize = 50 // SQLite max params is 999. We have 8 params per entry. 50 * 8 = 400.
         
@@ -155,7 +155,7 @@ class HistoryDatabaseManager {
                     entry.ckRecordId as Any? ?? NSNull()
                 ])
             }
-            try? _db.execute(query: sql, parameters: params)
+            try _db.execute(query: sql, parameters: params)
         }
     }
 
@@ -163,13 +163,13 @@ class HistoryDatabaseManager {
         try? exec("DELETE FROM reading_entries WHERE book_id = ?;", parameters: [bookId])
     }
 
-    func deleteEntries(bookIds: [Int]) {
+    func deleteEntries(bookIds: [Int]) throws {
         guard let _db, !bookIds.isEmpty else { return }
         let chunkSize = 500
         for i in stride(from: 0, to: bookIds.count, by: chunkSize) {
             let chunk = Array(bookIds[i..<min(i + chunkSize, bookIds.count)])
             let placeholders = chunk.map { _ in "?" }.joined(separator: ",")
-            try? _db.execute(
+            try _db.execute(
                 query: "DELETE FROM reading_entries WHERE book_id IN (\(placeholders));",
                 parameters: chunk
             )

--- a/Source/Managers/Database/HistoryViewModel.swift
+++ b/Source/Managers/Database/HistoryViewModel.swift
@@ -18,11 +18,6 @@ struct ReadingEntry: Codable, Identifiable, Hashable {
     }
 }
 
-private struct StoredReadingEntries: Codable {
-    let historyOrder: [Int]
-    let entries: [ReadingEntry]
-}
-
 class HistoryViewModel: ViewModelBase, ObservableObject {
     static let shared = HistoryViewModel()
 
@@ -50,28 +45,29 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
     }
 
     private let maxHistoryCount = 50
-    private let storageKey = "CloudReadingEntries"
 
-    /// For syncing KVS to CloudKit
+    /// Legacy UserDefaults keys — used only for migration
+    private let legacyStorageKey = "CloudReadingEntries"
     private let legacyHistoryKey = "iOSReadingEntries"
-
-    // Pending sync queue
-    private var pendingUploads: Set<String> = []
-    private var pendingDeletes: Set<String> = []
-    private let pendingQueue = DispatchQueue(label: "com.maktabah.history.pendingQueue", attributes: .concurrent)
-
-    /// Debounce upload saat navigasi halaman
+    private let legacyPendingUploadsKey = "HistoryPendingUploads"
+    private let legacyPendingDeletesKey = "HistoryPendingDeletes"
+    private let migrationFlag = "HistoryVM_SQLiteMigrated"
 
     /// Debounce for batched CloudKit deletions
     private var pendingCloudKitDeletes: Set<String> = []
     private var deleteDebounceTask: Task<Void, Never>?
+
+    // MARK: - Database
+
+    private var _db: SQLiteDatabase?
 
     var historyBookIds: [Int] {
         get { historyOrder }
         set {
             historyOrder = Array(newValue.prefix(maxHistoryCount))
             pruneOrphanedEntries()
-            persistAndReload(uploadEntry: nil)
+            saveHistoryOrder()
+            loadBooksData()
         }
     }
 
@@ -92,17 +88,12 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
     override init() {
         super.init()
-        loadFromUserDefaults()
-        loadPendingSync()
-
-        // Ensure initial books are loaded
-        loadBooksData()
-
-        // Migrate legacy KVS data if needed
+        setupDatabase()
+        migrateFromUserDefaultsIfNeeded()
         migrateLegacyKVSDataIfNeeded()
-
-        // Backfill missing CloudKit fields and upload to CloudKit
+        loadFromDatabase()
         backfillCloudKitFieldsIfNeeded()
+        loadBooksData()
 
         addObserver(
             forName: .bookIntegrated,
@@ -123,6 +114,157 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                   let newId = userInfo["newId"] as? Int else { return }
             self?.migrateBookId(from: oldId, to: newId)
         }
+    }
+
+    // MARK: - Database Setup
+
+    private func setupDatabase() {
+        guard let folderURL = AppConfig.folder(for: AppConfig.annotationsAndResultsFolder) else {
+            #if DEBUG
+            print("HistoryViewModel: No folder URL available for History database")
+            #endif
+            return
+        }
+
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: folderURL.path) {
+            try? fm.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        }
+
+        let url = folderURL.appendingPathComponent("History.sqlite")
+
+        do {
+            _db = try SQLiteDatabase(path: url.path)
+            enableWALMode()
+            try createTables()
+        } catch {
+            #if DEBUG
+            print("HistoryViewModel: Failed to setup database: \(error)")
+            #endif
+        }
+    }
+
+    private func enableWALMode() {
+        guard let _db else { return }
+        do {
+            let mode = try _db.fetch(query: "PRAGMA journal_mode = WAL;") { row in
+                row.string(at: 0) ?? ""
+            }.first
+
+            #if DEBUG
+            if mode?.lowercased() != "wal" {
+                print("HistoryViewModel: failed to enable WAL mode, current: \(mode ?? "unknown")")
+            }
+            #endif
+        } catch {
+            #if DEBUG
+            print("HistoryViewModel: error enabling WAL mode: \(error)")
+            #endif
+        }
+    }
+
+    private func createTables() throws {
+        try exec("""
+        CREATE TABLE IF NOT EXISTS reading_entries (
+            book_id INTEGER PRIMARY KEY,
+            last_content_id INTEGER,
+            last_opened_at REAL,
+            favorited_at REAL,
+            position_updated_at REAL,
+            updated_at REAL NOT NULL,
+            is_favorite INTEGER NOT NULL DEFAULT 0,
+            ck_record_id TEXT
+        );
+        """)
+
+        try exec("""
+        CREATE TABLE IF NOT EXISTS history_order (
+            position INTEGER PRIMARY KEY,
+            book_id INTEGER NOT NULL
+        );
+        """)
+
+        try exec("""
+        CREATE TABLE IF NOT EXISTS sync_pending (
+            ck_record_id TEXT PRIMARY KEY,
+            operation TEXT NOT NULL CHECK(operation IN ('upload', 'delete')),
+            queued_at INTEGER NOT NULL
+        );
+        """)
+
+        try exec("CREATE INDEX IF NOT EXISTS idx_re_favorite ON reading_entries (is_favorite, favorited_at);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_sync_pending_op ON sync_pending (operation, queued_at);")
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func exec(_ sql: String, parameters: [Any] = []) throws {
+        guard let _db else { return }
+        try _db.execute(query: sql, parameters: parameters)
+    }
+
+    private func transaction(_ block: () throws -> Void) throws {
+        guard let _db else { return }
+        try _db.transaction(block)
+    }
+
+    // MARK: - Core CRUD
+
+    private func upsertEntry(_ entry: ReadingEntry) {
+        let sql = """
+        INSERT OR REPLACE INTO reading_entries
+        (book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+        """
+        let params: [Any] = [
+            entry.bookId,
+            entry.lastContentId as Any? ?? NSNull(),
+            entry.lastOpenedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.favoritedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.positionUpdatedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
+            entry.updatedAt.timeIntervalSince1970,
+            entry.isFavorite ? 1 : 0,
+            entry.ckRecordId as Any? ?? NSNull(),
+        ]
+        try? _db?.execute(query: sql, parameters: params)
+    }
+
+    private func deleteEntry(bookId: Int) {
+        try? exec("DELETE FROM reading_entries WHERE book_id = ?;", parameters: [bookId])
+    }
+
+    private func saveHistoryOrder() {
+        try? transaction {
+            try exec("DELETE FROM history_order;")
+            for (position, bookId) in historyOrder.enumerated() {
+                try exec("INSERT INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
+            }
+        }
+    }
+
+    // MARK: - Load from Database
+
+    private func loadFromDatabase() {
+        guard let _db else { return }
+
+        let entries = (try? _db.fetch(query: "SELECT book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id FROM reading_entries;") { row -> ReadingEntry in
+            ReadingEntry(
+                bookId: row.int(at: 0),
+                lastContentId: row.isNull(at: 1) ? nil : row.int(at: 1),
+                lastOpenedAt: row.isNull(at: 2) ? nil : Date(timeIntervalSince1970: row.double(at: 2)),
+                favoritedAt: row.isNull(at: 3) ? nil : Date(timeIntervalSince1970: row.double(at: 3)),
+                positionUpdatedAt: row.isNull(at: 4) ? nil : Date(timeIntervalSince1970: row.double(at: 4)),
+                updatedAt: Date(timeIntervalSince1970: row.double(at: 5)),
+                isFavorite: row.int(at: 6) != 0,
+                ckRecordId: row.string(at: 7)
+            )
+        }) ?? []
+
+        entriesByBookId = Dictionary(uniqueKeysWithValues: entries.map { ($0.bookId, $0) })
+
+        historyOrder = (try? _db.fetch(query: "SELECT book_id FROM history_order ORDER BY position;") { row -> Int in
+            row.int(at: 0)
+        }) ?? []
     }
 
     // MARK: - Core Operations
@@ -157,7 +299,11 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         pruneOrphanedEntries()
-        persistAndReload(uploadEntry: entry)
+        upsertEntry(entry)
+        saveHistoryOrder()
+        loadBooksData()
+
+        CloudKitSyncManager.shared.uploadHistory(entries: [entry])
     }
 
     func updateLastContentId(_ contentId: Int, for bookId: Int) {
@@ -170,13 +316,13 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             }
             entriesByBookId[bookId] = entry
 
-            // Hanya simpan ke disk — tidak reload UI library (tidak ada perubahan visible)
-            persistToDiskOnly()
+            // Hanya simpan ke DB — tidak reload UI library (tidak ada perubahan visible)
+            upsertEntry(entry)
 
-        if let ckId = entry.ckRecordId {
-            addPendingSync(ckRecordId: ckId, operation: "upload")
-        }
-        CloudKitSyncManager.shared.uploadHistory(entries: [entry])
+            if let ckId = entry.ckRecordId {
+                addPendingSync(ckRecordId: ckId, operation: "upload")
+            }
+            CloudKitSyncManager.shared.uploadHistory(entries: [entry])
         } else {
             addBookToHistory(bookId)
             updateLastContentId(contentId, for: bookId)
@@ -208,7 +354,10 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         entriesByBookId[bookId] = entry
-        persistAndReload(uploadEntry: entry)
+        upsertEntry(entry)
+        loadBooksData()
+
+        CloudKitSyncManager.shared.uploadHistory(entries: [entry])
     }
 
     func removeHistory(for bookId: Int) {
@@ -219,12 +368,17 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 entry.lastOpenedAt = nil
                 entry.updatedAt = Date()
                 entriesByBookId[bookId] = entry
-                persistAndReload(uploadEntry: entry)
+                upsertEntry(entry)
+                saveHistoryOrder()
+                loadBooksData()
+                CloudKitSyncManager.shared.uploadHistory(entries: [entry])
             } else {
                 // Entry dihapus total — delete di CloudKit, tidak perlu upload
                 let ckId = entry.ckRecordId
                 entriesByBookId.removeValue(forKey: bookId)
-                persistAndReload(uploadEntry: nil)
+                deleteEntry(bookId: bookId)
+                saveHistoryOrder()
+                loadBooksData()
                 if let ckId {
                     addPendingSync(ckRecordId: ckId, operation: "delete")
                     pendingCloudKitDeletes.insert(ckId)
@@ -257,17 +411,19 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                     entry.lastOpenedAt = nil
                     entry.updatedAt = Date()
                     entriesByBookId[bookId] = entry
+                    upsertEntry(entry)
                 } else {
                     if let ckId = entry.ckRecordId {
                         ckIdsToDelete.append(ckId)
                     }
                     entriesByBookId.removeValue(forKey: bookId)
+                    deleteEntry(bookId: bookId)
                 }
             }
         }
 
-        // Entry sudah dihapus — deletes ditangani di bawah, tidak perlu upload
-        persistAndReload(uploadEntry: nil)
+        saveHistoryOrder()
+        loadBooksData()
 
         if !ckIdsToDelete.isEmpty {
             CloudKitSyncManager.shared.delete(ckRecordIds: ckIdsToDelete, target: .history)
@@ -278,48 +434,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         entriesByBookId[bookId]?.isFavorite ?? false
     }
 
-    // MARK: - Internal Load/Save
-
-    private func currentPayload() -> StoredReadingEntries {
-        StoredReadingEntries(
-            historyOrder: historyOrder,
-            entries: Array(entriesByBookId.values)
-        )
-    }
-
-    private func loadFromUserDefaults() {
-        if let data = UserDefaults.standard.data(forKey: storageKey),
-           let stored = try? JSONDecoder().decode(StoredReadingEntries.self, from: data)
-        {
-            applyPayload(stored, persistToDisk: false)
-        }
-    }
-
-    /// Persist ke disk + reload data buku di UI + upload satu entry ke CloudKit (jika ada).
-    private func persistAndReload(uploadEntry: ReadingEntry? = nil) {
-        let payload = currentPayload()
-        if let data = try? JSONEncoder().encode(payload) {
-            UserDefaults.standard.set(data, forKey: storageKey)
-        }
-
-        loadBooksData()
-
-        if let entry = uploadEntry, entry.ckRecordId != nil {
-            #if DEBUG
-            print("HistoryViewModel: upload 1 entry (bookId=\(entry.bookId))")
-            #endif
-            CloudKitSyncManager.shared.uploadHistory(entries: [entry])
-        }
-    }
-
-    /// Hanya simpan ke disk — tidak reload UI library, tidak upload ke CloudKit.
-    /// Digunakan saat navigasi halaman agar tidak memicu observer di LibraryViewManager.
-    private func persistToDiskOnly() {
-        let payload = currentPayload()
-        if let data = try? JSONEncoder().encode(payload) {
-            UserDefaults.standard.set(data, forKey: storageKey)
-        }
-    }
+    // MARK: - Pruning
 
     private func pruneOrphanedEntries() {
         let historySet = Set(historyOrder)
@@ -331,16 +446,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
         for bookId in toRemove {
             entriesByBookId.removeValue(forKey: bookId)
-        }
-    }
-
-    private func applyPayload(_ payload: StoredReadingEntries, persistToDisk: Bool) {
-        entriesByBookId = Dictionary(uniqueKeysWithValues: payload.entries.map { ($0.bookId, $0) })
-        historyOrder = payload.historyOrder
-        pruneOrphanedEntries()
-
-        if persistToDisk {
-            persistAndReload(uploadEntry: nil)
+            deleteEntry(bookId: bookId)
         }
     }
 
@@ -356,7 +462,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         favoriteBooks = fIds.compactMap { booksDict[$0] }
     }
 
-    // MARK: - CloudKit Migration & Sync Support
+    // MARK: - CloudKit Sync Support
 
     func getAllEntries() -> [ReadingEntry] {
         Array(entriesByBookId.values)
@@ -376,6 +482,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
             for bookId in bookIdsToDelete {
                 entriesByBookId.removeValue(forKey: bookId)
+                deleteEntry(bookId: bookId)
                 historyOrder.removeAll(where: { $0 == bookId })
                 didChange = true
             }
@@ -383,23 +490,23 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             // Updates/Insertions
             for remoteEntry in entriesToSave {
                 if let localEntry = entriesByBookId[remoteEntry.bookId] {
-                    // Conflict resolution based on updatedAt
                     let localModified = localEntry.updatedAt.timeIntervalSince1970
                     let remoteModified = remoteEntry.updatedAt.timeIntervalSince1970
 
                     if remoteModified > localModified {
                         entriesByBookId[remoteEntry.bookId] = remoteEntry
+                        upsertEntry(remoteEntry)
                         didChange = true
                     }
                 } else {
                     entriesByBookId[remoteEntry.bookId] = remoteEntry
+                    upsertEntry(remoteEntry)
                     didChange = true
                 }
             }
 
             if didChange {
                 // Sinkronkan urutan history di semua devices berdasarkan `lastOpenedAt`.
-                // Ini akan memastikan buku yang baru dibaca di device lain akan pindah ke atas.
                 let validHistoryEntries = entriesByBookId.values.filter { $0.lastOpenedAt != nil }
                 let sortedIds = validHistoryEntries
                     .sorted { ($0.lastOpenedAt ?? .distantPast) > ($1.lastOpenedAt ?? .distantPast) }
@@ -407,14 +514,9 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 historyOrder = Array(sortedIds.prefix(maxHistoryCount))
 
                 pruneOrphanedEntries()
-                // Persist but don't re-upload to cloud since it came from cloud
-                let payload = currentPayload()
-                if let data = try? JSONEncoder().encode(payload) {
-                    UserDefaults.standard.set(data, forKey: storageKey)
-                }
+                saveHistoryOrder()
                 loadBooksData()
             }
-            _ = didChange
         }
 
         if Thread.isMainThread {
@@ -424,74 +526,119 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 block()
             }
         }
-        return true // Operations on UserDefaults and memory dictionaries cannot 'fail' like a SQLite transaction lock, so we always report success
+        return true
     }
 
-    // MARK: - Pending Sync Handling
+    // MARK: - Pending Sync (SQLite)
 
     func addPendingSync(ckRecordId: String, operation: String) {
-        pendingQueue.sync(flags: .barrier) { [weak self] in
-            guard let self else { return }
+        guard let _db else { return }
+        do {
             if operation == "upload" {
-                if pendingDeletes.contains(ckRecordId) {
-                    return // Delete wins
-                }
-                pendingUploads.insert(ckRecordId)
-            } else {
-                pendingUploads.remove(ckRecordId)
-                pendingDeletes.insert(ckRecordId)
+                let count = try _db.fetch(
+                    query: "SELECT COUNT(*) FROM sync_pending WHERE ck_record_id = ? AND operation = 'delete';",
+                    parameters: [ckRecordId]
+                ) { $0.int64(at: 0) }.first ?? 0
+                if count > 0 { return } // Delete wins
+            } else if operation == "delete" {
+                try _db.execute(
+                    query: "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';",
+                    parameters: [ckRecordId]
+                )
             }
-            savePendingSync()
+            try _db.execute(
+                query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, ?, ?);",
+                parameters: [ckRecordId, operation, Int64(Date().timeIntervalSince1970)]
+            )
+        } catch {
+            #if DEBUG
+            print("HistoryViewModel: addPendingSync error: \(error)")
+            #endif
         }
     }
 
     func removePendingSync(ckRecordIds: [String]) {
-        pendingQueue.sync(flags: .barrier) { [weak self] in
-            guard let self else { return }
-            for id in ckRecordIds {
-                pendingUploads.remove(id)
-                pendingDeletes.remove(id)
-            }
-            savePendingSync()
-        }
+        guard let _db, !ckRecordIds.isEmpty else { return }
+        let placeholders = ckRecordIds.map { _ in "?" }.joined(separator: ",")
+        try? _db.execute(
+            query: "DELETE FROM sync_pending WHERE ck_record_id IN (\(placeholders));",
+            parameters: ckRecordIds
+        )
     }
 
     func fetchPendingSync(operation: String) -> [String] {
-        pendingQueue.sync {
-            if operation == "upload" {
-                Array(pendingUploads)
-            } else {
-                Array(pendingDeletes)
-            }
-        }
+        guard let _db else { return [] }
+        return (try? _db.fetch(
+            query: "SELECT ck_record_id FROM sync_pending WHERE operation = ? ORDER BY queued_at ASC;",
+            parameters: [operation]
+        ) { $0.string(at: 0) ?? "" }) ?? []
     }
 
-    private func loadPendingSync() {
-        pendingQueue.async(flags: .barrier) { [weak self] in
-            guard let self else { return }
-            if let upData = UserDefaults.standard.data(forKey: "HistoryPendingUploads"),
-               let upList = try? JSONDecoder().decode([String].self, from: upData)
-            {
-                pendingUploads = Set(upList)
-            }
-            if let delData = UserDefaults.standard.data(forKey: "HistoryPendingDeletes"),
-               let delList = try? JSONDecoder().decode([String].self, from: delData)
-            {
-                pendingDeletes = Set(delList)
+    // MARK: - Migration: UserDefaults → SQLite
+
+    private func migrateFromUserDefaultsIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: migrationFlag) else { return }
+        guard let _db else { return }
+
+        // Migrate main entries
+        if let data = UserDefaults.standard.data(forKey: legacyStorageKey),
+           let stored = try? JSONDecoder().decode(StoredReadingEntries.self, from: data)
+        {
+            do {
+                try _db.transaction {
+                    for entry in stored.entries {
+                        upsertEntry(entry)
+                    }
+                    // Preserve exact history order
+                    for (position, bookId) in stored.historyOrder.enumerated() {
+                        try exec("INSERT OR REPLACE INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
+                    }
+                }
+            } catch {
+                #if DEBUG
+                print("HistoryViewModel: Migration failed: \(error)")
+                #endif
+                return // Don't mark as migrated if failed
             }
         }
+
+        // Migrate pending sync
+        if let upData = UserDefaults.standard.data(forKey: legacyPendingUploadsKey),
+           let upList = try? JSONDecoder().decode([String].self, from: upData)
+        {
+            let now = Int64(Date().timeIntervalSince1970)
+            for ckId in upList {
+                try? _db.execute(
+                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
+                    parameters: [ckId, now]
+                )
+            }
+        }
+
+        if let delData = UserDefaults.standard.data(forKey: legacyPendingDeletesKey),
+           let delList = try? JSONDecoder().decode([String].self, from: delData)
+        {
+            let now = Int64(Date().timeIntervalSince1970)
+            for ckId in delList {
+                try? _db.execute(
+                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
+                    parameters: [ckId, now]
+                )
+            }
+        }
+
+        // Mark migrated and delete old UserDefaults data
+        UserDefaults.standard.set(true, forKey: migrationFlag)
+        UserDefaults.standard.removeObject(forKey: legacyStorageKey)
+        UserDefaults.standard.removeObject(forKey: legacyPendingUploadsKey)
+        UserDefaults.standard.removeObject(forKey: legacyPendingDeletesKey)
+
+        #if DEBUG
+        print("HistoryViewModel: Successfully migrated from UserDefaults to SQLite")
+        #endif
     }
 
-    private func savePendingSync() {
-        if let upData = try? JSONEncoder().encode(Array(pendingUploads)) {
-            UserDefaults.standard.set(upData, forKey: "HistoryPendingUploads")
-        }
-        if let delData = try? JSONEncoder().encode(Array(pendingDeletes)) {
-            UserDefaults.standard.set(delData, forKey: "HistoryPendingDeletes")
-        }
-    }
-
-    // MARK: - KVS Migration
+    // MARK: - KVS Migration (Legacy)
 
     func backfillCloudKitFieldsIfNeeded(completion: (([ReadingEntry]) -> Void)? = nil) {
         var backfilled = [ReadingEntry]()
@@ -503,13 +650,12 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 updated.ckRecordId = String(bookId)
                 entriesByBookId[bookId] = updated
                 backfilled.append(updated)
+                upsertEntry(updated)
                 didChange = true
             }
         }
 
         if didChange {
-            // Simpan ke disk + refresh UI; upload ditangani oleh caller via completion
-            persistToDiskOnly()
             loadBooksData()
         }
 
@@ -533,12 +679,15 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         if let legacy = legacyPayload {
-            // Apply it as cloud change
+            // Load current state from DB first
+            loadFromDatabase()
+
             for entry in legacy.entries {
                 if entriesByBookId[entry.bookId] == nil {
                     var migrated = entry
                     migrated.ckRecordId = String(entry.bookId)
                     entriesByBookId[entry.bookId] = migrated
+                    upsertEntry(migrated)
                 }
             }
 
@@ -548,15 +697,13 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 }
             }
 
-            // Simpan ke disk dan refresh UI
-            persistToDiskOnly()
-            loadBooksData()
+            saveHistoryOrder()
 
             // Upload semua entry hasil migrasi ke CloudKit (satu kali, batch)
             let migratedEntries = Array(entriesByBookId.values).filter { $0.ckRecordId != nil }
             if !migratedEntries.isEmpty {
                 Task {
-                    CloudKitSyncManager.shared.uploadHistory(entries: migratedEntries)
+                    CloudKitSyncManager.shared.uploadHistory(entries: migratedEntries, debounce: false)
                 }
             }
         }
@@ -581,12 +728,24 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             historyOrder[idx] = newId
         }
 
+        // Update DB: delete old, insert new
+        deleteEntry(bookId: oldId)
+        upsertEntry(migrated)
+        saveHistoryOrder()
+
         // Hapus entry lama dari CloudKit
         if let oldCkId = entry.ckRecordId {
             CloudKitSyncManager.shared.delete(ckRecordIds: [oldCkId], target: .history)
         }
 
-        // Upload hanya entry yang baru (hasil migrasi)
-        persistAndReload(uploadEntry: migrated)
+        // Upload entry baru
+        loadBooksData()
+        CloudKitSyncManager.shared.uploadHistory(entries: [migrated])
     }
+}
+
+/// Legacy struct — used only for migration from UserDefaults
+private struct StoredReadingEntries: Codable {
+    let historyOrder: [Int]
+    let entries: [ReadingEntry]
 }

--- a/Source/Managers/Database/HistoryViewModel.swift
+++ b/Source/Managers/Database/HistoryViewModel.swift
@@ -61,7 +61,6 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
     private let pendingQueue = DispatchQueue(label: "com.maktabah.history.pendingQueue", attributes: .concurrent)
 
     /// Debounce upload saat navigasi halaman
-    private var contentUpdateWorkItem: DispatchWorkItem?
 
     /// Debounce for batched CloudKit deletions
     private var pendingCloudKitDeletes: Set<String> = []
@@ -177,19 +176,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         if let ckId = entry.ckRecordId {
             addPendingSync(ckRecordId: ckId, operation: "upload")
         }
-
-            // Debounce upload ke CloudKit: tunggu 3 detik idle sebelum kirim
-            let capturedEntry = entry
-            contentUpdateWorkItem?.cancel()
-            let workItem = DispatchWorkItem { [weak self] in
-                guard self != nil else { return }
-                #if DEBUG
-                print("HistoryViewModel: debounced upload posisi buku \(bookId)")
-                #endif
-                CloudKitSyncManager.shared.uploadHistory(entries: [capturedEntry])
-            }
-            contentUpdateWorkItem = workItem
-            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 3.0, execute: workItem)
+        CloudKitSyncManager.shared.uploadHistory(entries: [entry])
         } else {
             addBookToHistory(bookId)
             updateLastContentId(contentId, for: bookId)

--- a/Source/Managers/ViewModels/HistoryViewModel.swift
+++ b/Source/Managers/ViewModels/HistoryViewModel.swift
@@ -285,7 +285,8 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
     // MARK: - Pruning
 
-    private func pruneOrphanedEntries() {
+    @discardableResult
+    private func pruneOrphanedEntries(deleteFromDB: Bool = true) -> [Int] {
         let historySet = Set(historyOrder)
         let toRemove = entriesByBookId.keys.filter { bookId in
             let entry = entriesByBookId[bookId]
@@ -293,10 +294,15 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             let hasHistory = historySet.contains(bookId)
             return !isFav && !hasHistory
         }
+        var removedIds = [Int]()
         for bookId in toRemove {
             entriesByBookId.removeValue(forKey: bookId)
-            HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
+            removedIds.append(bookId)
+            if deleteFromDB {
+                HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
+            }
         }
+        return removedIds
     }
 
     private func loadBooksData() {
@@ -321,7 +327,6 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         let block = { [weak self] in
             guard let self else { return }
             var didChange = false
-
             // Deletions
             let bookIdsToDelete = entriesByBookId.values
                 .compactMap { entry -> Int? in
@@ -329,14 +334,16 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                     return entry.bookId
                 }
 
+            var deletedIds = [Int]()
             for bookId in bookIdsToDelete {
                 entriesByBookId.removeValue(forKey: bookId)
-                HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
                 historyOrder.removeAll(where: { $0 == bookId })
+                deletedIds.append(bookId)
                 didChange = true
             }
 
             // Updates/Insertions
+            var upsertedEntries = [ReadingEntry]()
             for remoteEntry in entriesToSave {
                 if let localEntry = entriesByBookId[remoteEntry.bookId] {
                     let localModified = localEntry.updatedAt.timeIntervalSince1970
@@ -344,12 +351,12 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
                     if remoteModified > localModified {
                         entriesByBookId[remoteEntry.bookId] = remoteEntry
-                        HistoryDatabaseManager.shared.upsertEntry(remoteEntry)
+                        upsertedEntries.append(remoteEntry)
                         didChange = true
                     }
                 } else {
                     entriesByBookId[remoteEntry.bookId] = remoteEntry
-                    HistoryDatabaseManager.shared.upsertEntry(remoteEntry)
+                    upsertedEntries.append(remoteEntry)
                     didChange = true
                 }
             }
@@ -362,9 +369,23 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                     .map(\.bookId)
                 historyOrder = Array(sortedIds.prefix(maxHistoryCount))
 
-                pruneOrphanedEntries()
-                HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
+                let prunedIds = pruneOrphanedEntries(deleteFromDB: false)
+                deletedIds.append(contentsOf: prunedIds)
+
+                let finalOrder = historyOrder
                 loadBooksData()
+
+                DispatchQueue.global(qos: .background).async {
+                    try? HistoryDatabaseManager.shared.transaction {
+                        for bookId in deletedIds {
+                            HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
+                        }
+                        for entry in upsertedEntries {
+                            HistoryDatabaseManager.shared.upsertEntry(entry)
+                        }
+                        HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
+                    }
+                }
             }
         }
 
@@ -390,12 +411,19 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 updated.ckRecordId = String(bookId)
                 entriesByBookId[bookId] = updated
                 backfilled.append(updated)
-                HistoryDatabaseManager.shared.upsertEntry(updated)
                 didChange = true
             }
         }
 
+        let toUpdateDb = backfilled
         if didChange {
+            DispatchQueue.global(qos: .background).async {
+                try? HistoryDatabaseManager.shared.transaction {
+                    for entry in toUpdateDb {
+                        HistoryDatabaseManager.shared.upsertEntry(entry)
+                    }
+                }
+            }
             loadBooksData()
         }
 
@@ -422,12 +450,13 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             // Load current state from DB first
             loadFromDatabase()
 
+            var newEntries = [ReadingEntry]()
             for entry in legacy.entries {
                 if entriesByBookId[entry.bookId] == nil {
                     var migrated = entry
                     migrated.ckRecordId = String(entry.bookId)
                     entriesByBookId[entry.bookId] = migrated
-                    HistoryDatabaseManager.shared.upsertEntry(migrated)
+                    newEntries.append(migrated)
                 }
             }
 
@@ -437,12 +466,18 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 }
             }
 
-            HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
-
-            // Upload semua entry hasil migrasi ke CloudKit (satu kali, batch)
+            let finalOrder = historyOrder
             let migratedEntries = Array(entriesByBookId.values).filter { $0.ckRecordId != nil }
-            if !migratedEntries.isEmpty {
-                Task {
+
+            DispatchQueue.global(qos: .background).async {
+                try? HistoryDatabaseManager.shared.transaction {
+                    for entry in newEntries {
+                        HistoryDatabaseManager.shared.upsertEntry(entry)
+                    }
+                    HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
+                }
+                
+                if !migratedEntries.isEmpty {
                     CloudKitSyncManager.shared.uploadHistory(entries: migratedEntries, debounce: false)
                 }
             }

--- a/Source/Managers/ViewModels/HistoryViewModel.swift
+++ b/Source/Managers/ViewModels/HistoryViewModel.swift
@@ -377,12 +377,8 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
                 DispatchQueue.global(qos: .background).async {
                     try? HistoryDatabaseManager.shared.transaction {
-                        for bookId in deletedIds {
-                            HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
-                        }
-                        for entry in upsertedEntries {
-                            HistoryDatabaseManager.shared.upsertEntry(entry)
-                        }
+                        HistoryDatabaseManager.shared.deleteEntries(bookIds: deletedIds)
+                        HistoryDatabaseManager.shared.upsertEntries(upsertedEntries)
                         HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
                     }
                 }
@@ -419,9 +415,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         if didChange {
             DispatchQueue.global(qos: .background).async {
                 try? HistoryDatabaseManager.shared.transaction {
-                    for entry in toUpdateDb {
-                        HistoryDatabaseManager.shared.upsertEntry(entry)
-                    }
+                    HistoryDatabaseManager.shared.upsertEntries(toUpdateDb)
                 }
             }
             loadBooksData()
@@ -471,9 +465,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
             DispatchQueue.global(qos: .background).async {
                 try? HistoryDatabaseManager.shared.transaction {
-                    for entry in newEntries {
-                        HistoryDatabaseManager.shared.upsertEntry(entry)
-                    }
+                    HistoryDatabaseManager.shared.upsertEntries(newEntries)
                     HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
                 }
                 

--- a/Source/Managers/ViewModels/HistoryViewModel.swift
+++ b/Source/Managers/ViewModels/HistoryViewModel.swift
@@ -377,8 +377,8 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
                 DispatchQueue.global(qos: .background).async {
                     try? HistoryDatabaseManager.shared.transaction {
-                        HistoryDatabaseManager.shared.deleteEntries(bookIds: deletedIds)
-                        HistoryDatabaseManager.shared.upsertEntries(upsertedEntries)
+                        try HistoryDatabaseManager.shared.deleteEntries(bookIds: deletedIds)
+                        try HistoryDatabaseManager.shared.upsertEntries(upsertedEntries)
                         HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
                     }
                 }
@@ -415,7 +415,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         if didChange {
             DispatchQueue.global(qos: .background).async {
                 try? HistoryDatabaseManager.shared.transaction {
-                    HistoryDatabaseManager.shared.upsertEntries(toUpdateDb)
+                    try HistoryDatabaseManager.shared.upsertEntries(toUpdateDb)
                 }
             }
             loadBooksData()
@@ -465,7 +465,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
             DispatchQueue.global(qos: .background).async {
                 try? HistoryDatabaseManager.shared.transaction {
-                    HistoryDatabaseManager.shared.upsertEntries(newEntries)
+                    try HistoryDatabaseManager.shared.upsertEntries(newEntries)
                     HistoryDatabaseManager.shared.saveHistoryOrder(finalOrder)
                 }
                 

--- a/Source/Managers/ViewModels/HistoryViewModel.swift
+++ b/Source/Managers/ViewModels/HistoryViewModel.swift
@@ -46,27 +46,19 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
     private let maxHistoryCount = 50
 
-    /// Legacy UserDefaults keys — used only for migration
-    private let legacyStorageKey = "CloudReadingEntries"
+    /// Legacy UserDefaults keys
     private let legacyHistoryKey = "iOSReadingEntries"
-    private let legacyPendingUploadsKey = "HistoryPendingUploads"
-    private let legacyPendingDeletesKey = "HistoryPendingDeletes"
-    private let migrationFlag = "HistoryVM_SQLiteMigrated"
 
     /// Debounce for batched CloudKit deletions
     private var pendingCloudKitDeletes: Set<String> = []
     private var deleteDebounceTask: Task<Void, Never>?
-
-    // MARK: - Database
-
-    private var _db: SQLiteDatabase?
 
     var historyBookIds: [Int] {
         get { historyOrder }
         set {
             historyOrder = Array(newValue.prefix(maxHistoryCount))
             pruneOrphanedEntries()
-            saveHistoryOrder()
+            HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
             loadBooksData()
         }
     }
@@ -88,8 +80,8 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
     override init() {
         super.init()
-        setupDatabase()
-        migrateFromUserDefaultsIfNeeded()
+        HistoryDatabaseManager.shared.setupDatabase()
+        HistoryDatabaseManager.shared.migrateFromUserDefaultsIfNeeded()
         migrateLegacyKVSDataIfNeeded()
         loadFromDatabase()
         backfillCloudKitFieldsIfNeeded()
@@ -116,155 +108,12 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
     }
 
-    // MARK: - Database Setup
-
-    private func setupDatabase() {
-        guard let folderURL = AppConfig.folder(for: AppConfig.annotationsAndResultsFolder) else {
-            #if DEBUG
-            print("HistoryViewModel: No folder URL available for History database")
-            #endif
-            return
-        }
-
-        let fm = FileManager.default
-        if !fm.fileExists(atPath: folderURL.path) {
-            try? fm.createDirectory(at: folderURL, withIntermediateDirectories: true)
-        }
-
-        let url = folderURL.appendingPathComponent("History.sqlite")
-
-        do {
-            _db = try SQLiteDatabase(path: url.path)
-            enableWALMode()
-            try createTables()
-        } catch {
-            #if DEBUG
-            print("HistoryViewModel: Failed to setup database: \(error)")
-            #endif
-        }
-    }
-
-    private func enableWALMode() {
-        guard let _db else { return }
-        do {
-            let mode = try _db.fetch(query: "PRAGMA journal_mode = WAL;") { row in
-                row.string(at: 0) ?? ""
-            }.first
-
-            #if DEBUG
-            if mode?.lowercased() != "wal" {
-                print("HistoryViewModel: failed to enable WAL mode, current: \(mode ?? "unknown")")
-            }
-            #endif
-        } catch {
-            #if DEBUG
-            print("HistoryViewModel: error enabling WAL mode: \(error)")
-            #endif
-        }
-    }
-
-    private func createTables() throws {
-        try exec("""
-        CREATE TABLE IF NOT EXISTS reading_entries (
-            book_id INTEGER PRIMARY KEY,
-            last_content_id INTEGER,
-            last_opened_at REAL,
-            favorited_at REAL,
-            position_updated_at REAL,
-            updated_at REAL NOT NULL,
-            is_favorite INTEGER NOT NULL DEFAULT 0,
-            ck_record_id TEXT
-        );
-        """)
-
-        try exec("""
-        CREATE TABLE IF NOT EXISTS history_order (
-            position INTEGER PRIMARY KEY,
-            book_id INTEGER NOT NULL
-        );
-        """)
-
-        try exec("""
-        CREATE TABLE IF NOT EXISTS sync_pending (
-            ck_record_id TEXT PRIMARY KEY,
-            operation TEXT NOT NULL CHECK(operation IN ('upload', 'delete')),
-            queued_at INTEGER NOT NULL
-        );
-        """)
-
-        try exec("CREATE INDEX IF NOT EXISTS idx_re_favorite ON reading_entries (is_favorite, favorited_at);")
-        try exec("CREATE INDEX IF NOT EXISTS idx_sync_pending_op ON sync_pending (operation, queued_at);")
-    }
-
-    // MARK: - SQLite Helpers
-
-    private func exec(_ sql: String, parameters: [Any] = []) throws {
-        guard let _db else { return }
-        try _db.execute(query: sql, parameters: parameters)
-    }
-
-    private func transaction(_ block: () throws -> Void) throws {
-        guard let _db else { return }
-        try _db.transaction(block)
-    }
-
-    // MARK: - Core CRUD
-
-    private func upsertEntry(_ entry: ReadingEntry) {
-        let sql = """
-        INSERT OR REPLACE INTO reading_entries
-        (book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?);
-        """
-        let params: [Any] = [
-            entry.bookId,
-            entry.lastContentId as Any? ?? NSNull(),
-            entry.lastOpenedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
-            entry.favoritedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
-            entry.positionUpdatedAt?.timeIntervalSince1970 as Any? ?? NSNull(),
-            entry.updatedAt.timeIntervalSince1970,
-            entry.isFavorite ? 1 : 0,
-            entry.ckRecordId as Any? ?? NSNull(),
-        ]
-        try? _db?.execute(query: sql, parameters: params)
-    }
-
-    private func deleteEntry(bookId: Int) {
-        try? exec("DELETE FROM reading_entries WHERE book_id = ?;", parameters: [bookId])
-    }
-
-    private func saveHistoryOrder() {
-        try? transaction {
-            try exec("DELETE FROM history_order;")
-            for (position, bookId) in historyOrder.enumerated() {
-                try exec("INSERT INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
-            }
-        }
-    }
-
     // MARK: - Load from Database
 
     private func loadFromDatabase() {
-        guard let _db else { return }
-
-        let entries = (try? _db.fetch(query: "SELECT book_id, last_content_id, last_opened_at, favorited_at, position_updated_at, updated_at, is_favorite, ck_record_id FROM reading_entries;") { row -> ReadingEntry in
-            ReadingEntry(
-                bookId: row.int(at: 0),
-                lastContentId: row.isNull(at: 1) ? nil : row.int(at: 1),
-                lastOpenedAt: row.isNull(at: 2) ? nil : Date(timeIntervalSince1970: row.double(at: 2)),
-                favoritedAt: row.isNull(at: 3) ? nil : Date(timeIntervalSince1970: row.double(at: 3)),
-                positionUpdatedAt: row.isNull(at: 4) ? nil : Date(timeIntervalSince1970: row.double(at: 4)),
-                updatedAt: Date(timeIntervalSince1970: row.double(at: 5)),
-                isFavorite: row.int(at: 6) != 0,
-                ckRecordId: row.string(at: 7)
-            )
-        }) ?? []
-
-        entriesByBookId = Dictionary(uniqueKeysWithValues: entries.map { ($0.bookId, $0) })
-
-        historyOrder = (try? _db.fetch(query: "SELECT book_id FROM history_order ORDER BY position;") { row -> Int in
-            row.int(at: 0)
-        }) ?? []
+        let data = HistoryDatabaseManager.shared.loadFromDatabase()
+        entriesByBookId = Dictionary(uniqueKeysWithValues: data.entries.map { ($0.bookId, $0) })
+        historyOrder = data.historyOrder
     }
 
     // MARK: - Core Operations
@@ -299,8 +148,8 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         pruneOrphanedEntries()
-        upsertEntry(entry)
-        saveHistoryOrder()
+        HistoryDatabaseManager.shared.upsertEntry(entry)
+        HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
         loadBooksData()
 
         CloudKitSyncManager.shared.uploadHistory(entries: [entry])
@@ -317,10 +166,10 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
             entriesByBookId[bookId] = entry
 
             // Hanya simpan ke DB — tidak reload UI library (tidak ada perubahan visible)
-            upsertEntry(entry)
+            HistoryDatabaseManager.shared.upsertEntry(entry)
 
             if let ckId = entry.ckRecordId {
-                addPendingSync(ckRecordId: ckId, operation: "upload")
+                HistoryDatabaseManager.shared.addPendingSync(ckRecordId: ckId, operation: "upload")
             }
             CloudKitSyncManager.shared.uploadHistory(entries: [entry])
         } else {
@@ -354,7 +203,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         entriesByBookId[bookId] = entry
-        upsertEntry(entry)
+        HistoryDatabaseManager.shared.upsertEntry(entry)
         loadBooksData()
 
         CloudKitSyncManager.shared.uploadHistory(entries: [entry])
@@ -368,19 +217,19 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 entry.lastOpenedAt = nil
                 entry.updatedAt = Date()
                 entriesByBookId[bookId] = entry
-                upsertEntry(entry)
-                saveHistoryOrder()
+                HistoryDatabaseManager.shared.upsertEntry(entry)
+                HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
                 loadBooksData()
                 CloudKitSyncManager.shared.uploadHistory(entries: [entry])
             } else {
                 // Entry dihapus total — delete di CloudKit, tidak perlu upload
                 let ckId = entry.ckRecordId
                 entriesByBookId.removeValue(forKey: bookId)
-                deleteEntry(bookId: bookId)
-                saveHistoryOrder()
+                HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
+                HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
                 loadBooksData()
                 if let ckId {
-                    addPendingSync(ckRecordId: ckId, operation: "delete")
+                    HistoryDatabaseManager.shared.addPendingSync(ckRecordId: ckId, operation: "delete")
                     pendingCloudKitDeletes.insert(ckId)
 
                     deleteDebounceTask?.cancel()
@@ -411,18 +260,18 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                     entry.lastOpenedAt = nil
                     entry.updatedAt = Date()
                     entriesByBookId[bookId] = entry
-                    upsertEntry(entry)
+                    HistoryDatabaseManager.shared.upsertEntry(entry)
                 } else {
                     if let ckId = entry.ckRecordId {
                         ckIdsToDelete.append(ckId)
                     }
                     entriesByBookId.removeValue(forKey: bookId)
-                    deleteEntry(bookId: bookId)
+                    HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
                 }
             }
         }
 
-        saveHistoryOrder()
+        HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
         loadBooksData()
 
         if !ckIdsToDelete.isEmpty {
@@ -446,7 +295,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
         for bookId in toRemove {
             entriesByBookId.removeValue(forKey: bookId)
-            deleteEntry(bookId: bookId)
+            HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
         }
     }
 
@@ -482,7 +331,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
             for bookId in bookIdsToDelete {
                 entriesByBookId.removeValue(forKey: bookId)
-                deleteEntry(bookId: bookId)
+                HistoryDatabaseManager.shared.deleteEntry(bookId: bookId)
                 historyOrder.removeAll(where: { $0 == bookId })
                 didChange = true
             }
@@ -495,12 +344,12 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
 
                     if remoteModified > localModified {
                         entriesByBookId[remoteEntry.bookId] = remoteEntry
-                        upsertEntry(remoteEntry)
+                        HistoryDatabaseManager.shared.upsertEntry(remoteEntry)
                         didChange = true
                     }
                 } else {
                     entriesByBookId[remoteEntry.bookId] = remoteEntry
-                    upsertEntry(remoteEntry)
+                    HistoryDatabaseManager.shared.upsertEntry(remoteEntry)
                     didChange = true
                 }
             }
@@ -514,7 +363,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 historyOrder = Array(sortedIds.prefix(maxHistoryCount))
 
                 pruneOrphanedEntries()
-                saveHistoryOrder()
+                HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
                 loadBooksData()
             }
         }
@@ -529,115 +378,6 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         return true
     }
 
-    // MARK: - Pending Sync (SQLite)
-
-    func addPendingSync(ckRecordId: String, operation: String) {
-        guard let _db else { return }
-        do {
-            if operation == "upload" {
-                let count = try _db.fetch(
-                    query: "SELECT COUNT(*) FROM sync_pending WHERE ck_record_id = ? AND operation = 'delete';",
-                    parameters: [ckRecordId]
-                ) { $0.int64(at: 0) }.first ?? 0
-                if count > 0 { return } // Delete wins
-            } else if operation == "delete" {
-                try _db.execute(
-                    query: "DELETE FROM sync_pending WHERE ck_record_id = ? AND operation = 'upload';",
-                    parameters: [ckRecordId]
-                )
-            }
-            try _db.execute(
-                query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, ?, ?);",
-                parameters: [ckRecordId, operation, Int64(Date().timeIntervalSince1970)]
-            )
-        } catch {
-            #if DEBUG
-            print("HistoryViewModel: addPendingSync error: \(error)")
-            #endif
-        }
-    }
-
-    func removePendingSync(ckRecordIds: [String]) {
-        guard let _db, !ckRecordIds.isEmpty else { return }
-        let placeholders = ckRecordIds.map { _ in "?" }.joined(separator: ",")
-        try? _db.execute(
-            query: "DELETE FROM sync_pending WHERE ck_record_id IN (\(placeholders));",
-            parameters: ckRecordIds
-        )
-    }
-
-    func fetchPendingSync(operation: String) -> [String] {
-        guard let _db else { return [] }
-        return (try? _db.fetch(
-            query: "SELECT ck_record_id FROM sync_pending WHERE operation = ? ORDER BY queued_at ASC;",
-            parameters: [operation]
-        ) { $0.string(at: 0) ?? "" }) ?? []
-    }
-
-    // MARK: - Migration: UserDefaults → SQLite
-
-    private func migrateFromUserDefaultsIfNeeded() {
-        guard !UserDefaults.standard.bool(forKey: migrationFlag) else { return }
-        guard let _db else { return }
-
-        // Migrate main entries
-        if let data = UserDefaults.standard.data(forKey: legacyStorageKey),
-           let stored = try? JSONDecoder().decode(StoredReadingEntries.self, from: data)
-        {
-            do {
-                try _db.transaction {
-                    for entry in stored.entries {
-                        upsertEntry(entry)
-                    }
-                    // Preserve exact history order
-                    for (position, bookId) in stored.historyOrder.enumerated() {
-                        try exec("INSERT OR REPLACE INTO history_order (position, book_id) VALUES (?, ?);", parameters: [position, bookId])
-                    }
-                }
-            } catch {
-                #if DEBUG
-                print("HistoryViewModel: Migration failed: \(error)")
-                #endif
-                return // Don't mark as migrated if failed
-            }
-        }
-
-        // Migrate pending sync
-        if let upData = UserDefaults.standard.data(forKey: legacyPendingUploadsKey),
-           let upList = try? JSONDecoder().decode([String].self, from: upData)
-        {
-            let now = Int64(Date().timeIntervalSince1970)
-            for ckId in upList {
-                try? _db.execute(
-                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'upload', ?);",
-                    parameters: [ckId, now]
-                )
-            }
-        }
-
-        if let delData = UserDefaults.standard.data(forKey: legacyPendingDeletesKey),
-           let delList = try? JSONDecoder().decode([String].self, from: delData)
-        {
-            let now = Int64(Date().timeIntervalSince1970)
-            for ckId in delList {
-                try? _db.execute(
-                    query: "INSERT OR REPLACE INTO sync_pending (ck_record_id, operation, queued_at) VALUES (?, 'delete', ?);",
-                    parameters: [ckId, now]
-                )
-            }
-        }
-
-        // Mark migrated and delete old UserDefaults data
-        UserDefaults.standard.set(true, forKey: migrationFlag)
-        UserDefaults.standard.removeObject(forKey: legacyStorageKey)
-        UserDefaults.standard.removeObject(forKey: legacyPendingUploadsKey)
-        UserDefaults.standard.removeObject(forKey: legacyPendingDeletesKey)
-
-        #if DEBUG
-        print("HistoryViewModel: Successfully migrated from UserDefaults to SQLite")
-        #endif
-    }
-
     // MARK: - KVS Migration (Legacy)
 
     func backfillCloudKitFieldsIfNeeded(completion: (([ReadingEntry]) -> Void)? = nil) {
@@ -650,7 +390,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 updated.ckRecordId = String(bookId)
                 entriesByBookId[bookId] = updated
                 backfilled.append(updated)
-                upsertEntry(updated)
+                HistoryDatabaseManager.shared.upsertEntry(updated)
                 didChange = true
             }
         }
@@ -687,7 +427,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                     var migrated = entry
                     migrated.ckRecordId = String(entry.bookId)
                     entriesByBookId[entry.bookId] = migrated
-                    upsertEntry(migrated)
+                    HistoryDatabaseManager.shared.upsertEntry(migrated)
                 }
             }
 
@@ -697,7 +437,7 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
                 }
             }
 
-            saveHistoryOrder()
+            HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
 
             // Upload semua entry hasil migrasi ke CloudKit (satu kali, batch)
             let migratedEntries = Array(entriesByBookId.values).filter { $0.ckRecordId != nil }
@@ -729,9 +469,9 @@ class HistoryViewModel: ViewModelBase, ObservableObject {
         }
 
         // Update DB: delete old, insert new
-        deleteEntry(bookId: oldId)
-        upsertEntry(migrated)
-        saveHistoryOrder()
+        HistoryDatabaseManager.shared.deleteEntry(bookId: oldId)
+        HistoryDatabaseManager.shared.upsertEntry(migrated)
+        HistoryDatabaseManager.shared.saveHistoryOrder(historyOrder)
 
         // Hapus entry lama dari CloudKit
         if let oldCkId = entry.ckRecordId {


### PR DESCRIPTION
This pull request migrates the `HistoryViewModel` storage layer from a UserDefaults-based JSON blob to a robust SQLite implementation (`History.sqlite`) and extracts the database operations into a dedicated `HistoryDatabaseManager` to enforce separation of concerns.

Key changes:
- Creates `HistoryDatabaseManager` to handle SQLite connections, schemas, and CRUD operations.
- Replaces in-memory concurrent queues and UserDefaults storage with a `sync_pending` SQLite table to ensure thread safety and avoid race conditions during CloudKit syncs.
- Adopts Write-Ahead Logging (WAL) and atomic transactions to prevent data corruption during app crashes or mid-write interruptions.
- Implements one-time automatic migration from legacy UserDefaults storage without data loss, removing stale legacy keys upon success.
- Updates `CloudKitSyncManager` to utilize the new database manager for tracking pending syncs.
- Introduces debounce batching for CloudKit `uploadResultsData` and `uploadHistory` to optimize network requests.
- Integrates `History.sqlite` into the custom storage folder and iCloud migration paths.