### PR TITLE
fix: remove actions/checkout to prevent CI hang during Jules PR Review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,9 +16,6 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-
       - name: Jules PR Reviewer
         uses: thalesraymond/jules-pr-reviewer@v1
         with:


### PR DESCRIPTION
### Code Health Summary
- Target File(s): `.github/workflows/pr-review.yml`
- Action Taken: Removed the `actions/checkout` step.
- Complexity Impact: Simplified the workflow, reducing overhead and preventing a known network/cloning hang.
- Test Status: Verified YAML syntax validity.

**Problem:**
The Jules PR Review action was hanging indefinitely during the cloning phase ("gak selesai-selesai cloning") because it included an unnecessary `actions/checkout` step.

**Solution:**
Removed the `actions/checkout` step from `.github/workflows/pr-review.yml`. The `thalesraymond/jules-pr-reviewer` action fetches diffs and files via the GitHub REST API and does not require the repository to be cloned locally.

**Testing:**
Verified the syntax of the modified YAML file. The workflow now executes purely via API calls, bypassing the problematic cloning step entirely.

---
*PR created automatically by Jules for task [1974515647498094122](https://jules.google.com/task/1974515647498094122) started by @bismillah-100*