### PR TITLE
fix(macOS): resolve data desync during book migration and fix window tab UI bugs

### DIFF
--- a/Source/Al-Qur'an/QuranSidebarVC.swift
+++ b/Source/Al-Qur'an/QuranSidebarVC.swift
@@ -11,7 +11,6 @@ class QuranSidebarVC: NSViewController {
     @IBOutlet weak var outlineView: NSOutlineView!
     @IBOutlet weak var scrollView: NSScrollView!
     @IBOutlet weak var searchField: DSFSearchField!
-    @IBOutlet weak var searchContainer: NSView!
     @IBOutlet weak var xBtn: NSButton!
 
     private let manager: QuranDataManager = .shared
@@ -111,20 +110,16 @@ class QuranSidebarVC: NSViewController {
     }
 
     @objc func unhideSearchField() {
-        #if DEBUG
-        print("unhideSearchField")
-        #endif
-
         let hide = searchField.isHidden
 
-        searchContainer.isHidden = !hide
         searchField.isHidden = !hide
 
         // 3. Buat Constraint yang Baru
         if hide {
             // KONDISI 1: TIDAK TERSEMBUNYI (Unhide)
             scrollView.automaticallyAdjustsContentInsets = false
-            scrollView.contentInsets.top = 88
+            scrollView.contentInsets.top = view.safeAreaInsets.top +
+                                           searchField.frame.height + 8
             searchField.becomeFirstResponder()
         } else {
             // KONDISI 2: TERSEMBUNYI (Hide)

--- a/Source/Managers/BookUpdate/BookImportView.swift
+++ b/Source/Managers/BookUpdate/BookImportView.swift
@@ -834,6 +834,8 @@ struct OfflineImportFormView: View {
             }
 
             BookPageCache.shared.remove(bookId: oldId)
+            BookConnection.invalidateTOC(for: oldId)
+            BookConnection.totalPartsCache.removeObject(forKey: NSString(string: String(oldId)))
 
             // Phase 3: Upload ke CloudKit SETELAH library data segar.
             // Urutan ini mencegah race condition di mana device lain menerima

--- a/Source/Managers/Database/BookConnection.swift
+++ b/Source/Managers/Database/BookConnection.swift
@@ -16,12 +16,14 @@ import SQLite3
 class BookConnection {
     private(set) var db: SQLiteDatabase?
     static let tocTreeCache = NSCache<NSNumber, NSArray>()
-    private let totalPartsCache = NSCache<NSString, NSNumber>()
+    static let totalPartsCache: NSCache<NSString, NSNumber> = {
+        let cache = NSCache<NSString, NSNumber>()
+        cache.countLimit = 100 // max 100 books di cache
+        cache.name = "BookTotalPartsCache"
+        return cache
+    }()
 
-    init() {
-        totalPartsCache.countLimit = 100 // max 100 books di cache
-        totalPartsCache.name = "BookTotalPartsCache"
-    }
+    init() {}
 
     deinit {
         db = nil
@@ -373,14 +375,14 @@ extension BookConnection {
         let key = bkid as NSString
 
         // Cek cache dulu
-        if let cached = totalPartsCache.object(forKey: key) {
+        if let cached = Self.totalPartsCache.object(forKey: key) {
             return cached.intValue
         }
 
         let total = calculateTotalParts(bkid: bkid)
 
         // Simpan ke cache
-        totalPartsCache.setObject(NSNumber(value: total), forKey: key)
+        Self.totalPartsCache.setObject(NSNumber(value: total), forKey: key)
 
         return total
     }
@@ -537,5 +539,9 @@ extension BookConnection {
 
         Self.tocTreeCache.setObject(rootNodes as NSArray, forKey: key)
         return rootNodes
+    }
+
+    static func invalidateTOC(for bookId: Int) {
+        tocTreeCache.removeObject(forKey: NSNumber(value: bookId))
     }
 }

--- a/Source/Managers/ViewModels/LibraryViewModel.swift
+++ b/Source/Managers/ViewModels/LibraryViewModel.swift
@@ -698,6 +698,7 @@ final class LibraryViewModel: ViewModelBase {
         }
     }
 
+    // MARK: macOS Implementation
     #if os(macOS)
     private func setupMacOSBindings() {
         $searchQuery
@@ -1031,6 +1032,11 @@ final class LibraryViewModel: ViewModelBase {
             // Optional string routing handled by view manager if needed,
             // but typically restore selection handles it.
             updateSubject.send(.expandItem(bookName))
+
+            /* Removed iOS implementation cause this func is
+             macOS only. see line 701 #if os(macOS)
+             func setupMacOSBinding its closed #endif
+             on line 1054 func findCategoryInDisplayed. */
         }
     }
 

--- a/Source/Managers/ViewModels/LibraryViewModel.swift
+++ b/Source/Managers/ViewModels/LibraryViewModel.swift
@@ -172,9 +172,7 @@ final class LibraryViewModel: ViewModelBase {
             _authorHierarchy = dataManager.buildAuthorHierarchy()
             _hasBuiltAuthorHierarchy = true
         }
-        setBaseCategories(rootCategories, reload: false)
-        resetAuthorPagination()
-        updateDisplayedCategories()
+        applyFilter(filterMode)
         state = .loaded
         hasLoadedLibrary = dataManager.isDataLoaded
     }
@@ -633,7 +631,7 @@ final class LibraryViewModel: ViewModelBase {
                         _authorHierarchy = dataManager.buildAuthorHierarchy()
                         _hasBuiltAuthorHierarchy = true
                     }
-                    updateDisplayedCategories()
+                    applyFilter(filterMode)
                 }
             }
             .store(in: &cancellables)
@@ -741,9 +739,7 @@ final class LibraryViewModel: ViewModelBase {
                 cat.children = newBooks
                 return cat
             }()]
-            #if os(macOS)
             updateSubject.send(.reloadData)
-            #endif
             return
         }
 
@@ -755,17 +751,13 @@ final class LibraryViewModel: ViewModelBase {
         if oldIds == newIds { return } // Tidak ada perubahan urutan atau penambahan/pengurangan
 
         var currentBooks = oldBooks
-        #if os(macOS)
         updateSubject.send(.beginUpdates)
-        #endif
 
         // Hapus item lama yang sudah tidak ada
         let newIdSet = Set(newIds)
         for (index, oldBook) in currentBooks.enumerated().reversed() {
             if !newIdSet.contains(oldBook.id) {
-                #if os(macOS)
                 updateSubject.send(.removeItems(IndexSet(integer: index), parent: nil))
-                #endif
                 currentBooks.remove(at: index)
             }
         }
@@ -775,9 +767,7 @@ final class LibraryViewModel: ViewModelBase {
         for (newIndex, newBook) in newBooks.enumerated() {
             if let oldIndex = currentBooks.firstIndex(where: { $0.id == newBook.id }) {
                 if oldIndex != newIndex {
-                    #if os(macOS)
                     updateSubject.send(.moveItem(from: oldIndex, to: newIndex, parent: nil))
-                    #endif
                     let movedBook = currentBooks.remove(at: oldIndex)
                     currentBooks.insert(movedBook, at: newIndex)
                     firstCat.children = currentBooks
@@ -785,14 +775,10 @@ final class LibraryViewModel: ViewModelBase {
             } else {
                 currentBooks.insert(newBook, at: newIndex)
                 firstCat.children = currentBooks
-                #if os(macOS)
                 updateSubject.send(.insertItems(IndexSet(integer: newIndex), parent: nil))
-                #endif
             }
         }
-        #if os(macOS)
         updateSubject.send(.endUpdates)
-        #endif
     }
 
     private func handleBooksChanged(_ notification: Notification) {
@@ -801,7 +787,6 @@ final class LibraryViewModel: ViewModelBase {
             if let category = findCategoryInDisplayed(categoryId) {
                 bookLookup[book.book] = (category, book)
 
-                #if os(macOS)
                 if searchQuery.isEmpty {
                     updateSubject.send(.expandItem(category))
                     updateSubject.send(.reloadItem(category, reloadChildren: true))
@@ -818,7 +803,6 @@ final class LibraryViewModel: ViewModelBase {
                     displayedCategories = filtered
                     updateSubject.send(.reloadData)
                 }
-                #endif
             }
         }
         if !payload.updatedBookIds.isEmpty {
@@ -834,9 +818,7 @@ final class LibraryViewModel: ViewModelBase {
                 bookLookup[book.book] = (value.category, book)
                 break
             }
-            #if os(macOS)
             updateSubject.send(.reloadItem(book, reloadChildren: false))
-            #endif
         }
     }
 
@@ -851,38 +833,28 @@ final class LibraryViewModel: ViewModelBase {
 
         if isDownloadModal {
             if let childIndex = parent.children.firstIndex(where: { ($0 as? BooksData)?.id == bookId }) {
-                #if os(macOS)
                 updateSubject.send(.beginUpdates)
-                #endif
 
                 if parent.children.count == 1 {
                     parent.children.remove(at: childIndex)
                     selectedBookIds.remove(bookId)
                     if let index = displayedCategories.firstIndex(where: { $0 === parent }) {
                         displayedCategories.remove(at: index)
-                        #if os(macOS)
                         updateSubject.send(.removeItems(IndexSet(integer: index), parent: nil))
-                        #endif
                     }
                     baseCategories = displayedCategories
                 } else {
                     parent.children.remove(at: childIndex)
-                    #if os(macOS)
                     updateSubject.send(.removeItems(IndexSet(integer: childIndex), parent: parent))
-                    #endif
                 }
 
-                #if os(macOS)
                 updateSubject.send(.endUpdates)
                 updateSubject.send(.reloadItem(parent, reloadChildren: false))
-                #endif
             }
         } else {
-            #if os(macOS)
             if let book = parent.children.first(where: { ($0 as? BooksData)?.id == bookId }) {
                 updateSubject.send(.reloadItem(book, reloadChildren: false))
             }
-            #endif
         }
     }
 
@@ -905,9 +877,7 @@ final class LibraryViewModel: ViewModelBase {
                 let category = list[i]
 
                 if let bookIndex = category.children.firstIndex(where: { ($0 as? BooksData)?.id == bookId }) {
-                    #if os(macOS)
                     updateSubject.send(.removeItems(IndexSet(integer: bookIndex), parent: category))
-                    #endif
                     category.children.remove(at: bookIndex)
                     anyChanged = true
                 }
@@ -918,9 +888,7 @@ final class LibraryViewModel: ViewModelBase {
                         var subList = [sub]
                         if findAndRemove(in: &subList, parent: category) {
                             if subList.isEmpty {
-                                #if os(macOS)
                                 updateSubject.send(.removeItems(IndexSet(integer: j), parent: category))
-                                #endif
                                 category.children.remove(at: j)
                             }
                             subChanged = true
@@ -1033,9 +1001,7 @@ final class LibraryViewModel: ViewModelBase {
                     let clone = category.copy() as! CategoryData
                     clone.children = []
                     let insertIndex = insertCategory(clone, into: &parent.children)
-                    #if os(macOS)
                     updateSubject.send(.insertItems(IndexSet(integer: insertIndex), parent: parent))
-                    #endif
                     currentParent = clone
                 }
             } else {
@@ -1047,9 +1013,7 @@ final class LibraryViewModel: ViewModelBase {
                     var list = displayedCategories
                     let insertIndex = insertCategory(clone, into: &list)
                     displayedCategories = list
-                    #if os(macOS)
                     updateSubject.send(.insertItems(IndexSet(integer: insertIndex), parent: nil))
-                    #endif
                     currentParent = clone
                 }
             }
@@ -1057,8 +1021,9 @@ final class LibraryViewModel: ViewModelBase {
 
         guard let leaf = currentParent else { return }
 
-        #if os(macOS)
-        if let insertIndex = insertBook(book, originalCategory: originalLeaf, targetCategory: leaf) {
+        let insertIndex = insertBook(book, originalCategory: originalLeaf, targetCategory: leaf)
+
+        if let insertIndex {
             updateSubject.send(.insertItems(IndexSet(integer: insertIndex), parent: leaf))
         }
 
@@ -1067,10 +1032,6 @@ final class LibraryViewModel: ViewModelBase {
             // but typically restore selection handles it.
             updateSubject.send(.expandItem(bookName))
         }
-        #else
-        // Trigger @Published update for iOS
-        displayedCategories = displayedCategories
-        #endif
     }
 
     func findCategoryInDisplayed(_ categoryId: Int) -> CategoryData? {

--- a/Source/Managers/ViewModels/SearchViewModel.swift
+++ b/Source/Managers/ViewModels/SearchViewModel.swift
@@ -70,6 +70,8 @@ final class SearchViewModel: ViewModelBase {
     let rowProgressDidUpdate = PassthroughSubject<(completed: Int, total: Int), Never>()
     /// Dikirim sekali saat search selesai sepenuhnya
     let searchDidComplete = PassthroughSubject<Void, Never>()
+    /// Dikirim saat data dimigrasi atau butuh reload UI secara penuh
+    let searchNeedsReload = PassthroughSubject<Void, Never>()
     #endif
 
     private let bkConn = BookConnection()
@@ -90,9 +92,12 @@ final class SearchViewModel: ViewModelBase {
 
     private let searchEngine = SearchEngine()
     private let ldm = LibraryDataManager.shared
+    private var searchWork: Task<Void, Never>?
+
+    #if os(iOS)
     private let filterSubject = PassthroughSubject<String, Never>()
     private let refreshSubject = PassthroughSubject<Void, Never>()
-    private var searchWork: Task<Void, Never>?
+    #endif
 
     // MARK: - Init
 
@@ -125,11 +130,17 @@ final class SearchViewModel: ViewModelBase {
             .sink { [weak self] in self?.updateDisplayedCategories() }
             .store(in: &cancellables)
 
+        #endif
+
         addObserver(
             forName: .bookIntegrated, object: nil, queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                #if os(macOS)
+                self?.searchNeedsReload.send(())
+                #else
                 self?.refreshSubject.send(())
+                #endif
             }
         }
 
@@ -137,11 +148,13 @@ final class SearchViewModel: ViewModelBase {
             forName: .booksChanged, object: nil, queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                #if os(macOS)
+                self?.searchNeedsReload.send(())
+                #else
                 self?.refreshSubject.send(())
+                #endif
             }
         }
-
-        #endif
 
         addObserver(
             forName: .bookIdMigrated, object: nil, queue: .main
@@ -201,6 +214,11 @@ final class SearchViewModel: ViewModelBase {
         if targetBookId == String(oldId) {
             targetBookId = String(newId)
         }
+        searchNeedsReload.send(())
+        #endif
+
+        #if os(iOS)
+        updateDisplayedCategories()
         #endif
     }
 

--- a/Source/Models/NotificationName.swift
+++ b/Source/Models/NotificationName.swift
@@ -14,4 +14,7 @@ extension Notification.Name {
     static let didChangeBackground = Notification.Name("didChangeBackground")
     static let didChangeFont = Notification.Name("didChangeFont")
     static let didChangeLineHeight = Notification.Name("didChangeLineHeight")
+
+    // MARK: - WINDOW OBSERVATIONS
+    static let windowTabBarDidChange = Notification.Name("windowTabBarDidChange")
 }

--- a/Source/Models/ResultsViewModel.swift
+++ b/Source/Models/ResultsViewModel.swift
@@ -57,6 +57,21 @@ class ResultsViewModel {
             name: .savedResultsTreeDidUpdate,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleBookIdMigrated(_:)),
+            name: .bookIdMigrated,
+            object: nil
+        )
+    }
+
+    @objc private func handleBookIdMigrated(_ notification: Notification) {
+        Task {
+            await getFolders()
+            await dbLoadAllResults()
+            notifyChange(.fullReload)
+        }
     }
 
     @objc private func handleSavedResultsTreeDidUpdate() {

--- a/Source/Protocols/AppDelegate.swift
+++ b/Source/Protocols/AppDelegate.swift
@@ -657,6 +657,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         w.displayIfNeeded()
     }
 
+    @IBAction func newTabWindow(_ sender: Any?) {
+        guard let keyWindow else { return }
+        keyWindow.newWindowForTab(sender)
+    }
+
     deinit {
         if let windowObserver {
             NotificationCenter.default.removeObserver(windowObserver)

--- a/Source/Reader/SidebarVC.swift
+++ b/Source/Reader/SidebarVC.swift
@@ -12,7 +12,6 @@ class SidebarVC: NSViewController {
     @IBOutlet weak var outlineView: NSOutlineView!
     @IBOutlet weak var scrollView: NSScrollView!
     @IBOutlet weak var searchField: DSFSearchField!
-    @IBOutlet weak var searchContainer: NSView!
     @IBOutlet weak var xBtn: NSButton!
 
     weak var delegate: SidebarDelegate?
@@ -39,6 +38,9 @@ class SidebarVC: NSViewController {
         }
     }
 
+    private var windowsObservation: NSKeyValueObservation?
+    private var tabBarObservation: NSObjectProtocol?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         xBtn.isEnabled = false
@@ -64,6 +66,33 @@ class SidebarVC: NSViewController {
 
     override func viewDidAppear() {
         super.viewDidAppear()
+        startWindowObservation()
+    }
+
+    func startWindowObservation() {
+        guard windowsObservation == nil,
+              let window = view.window,
+              let tabGroup = window.tabGroup
+        else { return }
+
+        windowsObservation = tabGroup.observe(
+            \.windows,
+             options: []
+        ) { _,_ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                updateScrollViewInsets(searchField.isHidden)
+            }
+        }
+
+        tabBarObservation = NotificationCenter.default.addObserver(
+            forName: .windowTabBarDidChange,
+            object: nil, queue: .main,
+            using: { [weak self] _ in
+                guard let self else { return }
+                updateScrollViewInsets(searchField.isHidden)
+            }
+        )
     }
 
     @IBAction func performFindPanelAction(_ sender: Any) {
@@ -76,8 +105,6 @@ class SidebarVC: NSViewController {
             scrollView.drawsBackground = true
             scrollView.backgroundColor = color.nsColor
         }
-        searchContainer.wantsLayer = true
-        searchContainer.layer?.backgroundColor = color.nsColor.cgColor
         // Update outline view
         outlineView.backgroundColor = .clear
     }
@@ -92,19 +119,17 @@ class SidebarVC: NSViewController {
         searchFieldIsHidden.toggle()
         let hide = searchFieldIsHidden
 
-        searchContainer.isHidden = hide
         searchField.isHidden = hide
+        updateScrollViewInsets(hide)
+    }
 
-        // 3. Buat Constraint yang Baru
-        if !hide {
-            // KONDISI 1: TIDAK TERSEMBUNYI (Unhide)
+    func updateScrollViewInsets(_ searchFieldHidden: Bool) {
+        if !searchFieldHidden {
             scrollView.automaticallyAdjustsContentInsets = false
-            scrollView.contentInsets.top = 88
+            scrollView.contentInsets.top = view.safeAreaInsets.top +
+                                           searchField.frame.height + 8
             searchField.becomeFirstResponder()
         } else {
-            // KONDISI 2: TERSEMBUNYI (Hide)
-            // Hubungkan scrollView top ke superview top dengan constant 0
-            // Asumsi superview dari scrollView adalah view utama ViewController
             scrollView.automaticallyAdjustsContentInsets = true
         }
     }

--- a/Source/Reader/SidebarVC.swift
+++ b/Source/Reader/SidebarVC.swift
@@ -27,7 +27,7 @@ class SidebarVC: NSViewController {
     }
 
     var db: BookConnection!
-    
+
     var previousSelectedRow: Int?
 
     var enableDelegate: Bool = true
@@ -67,6 +67,13 @@ class SidebarVC: NSViewController {
     override func viewDidAppear() {
         super.viewDidAppear()
         startWindowObservation()
+    }
+
+    deinit {
+        windowsObservation = nil
+        if let obs = tabBarObservation {
+            NotificationCenter.default.removeObserver(obs)
+        }
     }
 
     func startWindowObservation() {
@@ -136,7 +143,7 @@ class SidebarVC: NSViewController {
 
     func updateTOC(_ nodes: [TOCNode]) {
         self.tocTree = nodes
-        
+
         var flat: [TOCNode] = []
         func traverse(_ node: TOCNode) {
             flat.append(node)
@@ -144,7 +151,7 @@ class SidebarVC: NSViewController {
         }
         for node in nodes { traverse(node) }
         self.flatNodes = flat
-        
+
         self.outlineView.reloadData()
         Task { await self.rebuildLookupCache() }
     }

--- a/Source/Search/OptionSearchVC.swift
+++ b/Source/Search/OptionSearchVC.swift
@@ -315,6 +315,13 @@ class OptionSearchVC: NSViewController {
                 resetProgressBar()
             }
             .store(in: &cancellables)
+
+        viewModel.searchNeedsReload
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
     }
 
     private func setupTableView() {

--- a/Source/View/MainWindow.swift
+++ b/Source/View/MainWindow.swift
@@ -45,6 +45,17 @@ class MainWindow: NSWindow {
         updateUI()
     }
 
+    override func newWindowForTab(_ sender: Any?) {
+        let newWindowController = WindowController()
+
+        // Tambahkan sebagai tab
+        if let newWindow = newWindowController.window as? MainWindow {
+            addTabbedWindow(newWindow, ordered: .above)
+            newWindow.setupContentView(restoreState: false)
+            newWindow.makeKeyAndOrderFront(nil)
+        }
+    }
+
     func setupContentView(restoreState: Bool = true) {
         let currentFrame = frame
         // Restore last mode

--- a/Source/View/MainWindow.swift
+++ b/Source/View/MainWindow.swift
@@ -56,6 +56,13 @@ class MainWindow: NSWindow {
         }
     }
 
+    override func toggleTabBar(_ sender: Any?) {
+        super.toggleTabBar(sender)
+        NotificationCenter.default.post(
+            name: .windowTabBarDidChange, object: nil
+        )
+    }
+
     func setupContentView(restoreState: Bool = true) {
         let currentFrame = frame
         // Restore last mode

--- a/Source/View/WindowController.swift
+++ b/Source/View/WindowController.swift
@@ -43,18 +43,6 @@ class WindowController: NSWindowController {
         }
         self.window = window
     }
-    
-    @IBAction override func newWindowForTab(_ sender: Any?) {
-        // PERBAIKAN: Instance otomatis disimpan di windowDidLoad
-        let newWindowController = WindowController()
-
-        // Tambahkan sebagai tab
-        if let newWindow = newWindowController.window as? MainWindow {
-            window?.addTabbedWindow(newWindow, ordered: .above)
-            newWindow.setupContentView(restoreState: false)
-            newWindow.makeKeyAndOrderFront(nil)
-        }
-    }
 
     static func showPopOver(sender: NSButton, viewController: NSViewController) {
         let popover = NSPopover()

--- a/Source/XIB/Base.lproj/MainMenu.xib
+++ b/Source/XIB/Base.lproj/MainMenu.xib
@@ -104,7 +104,7 @@
                         <items>
                             <menuItem title="New Tab" keyEquivalent="t" id="xh5-uq-cyo">
                                 <connections>
-                                    <action selector="newWindowForTab:" target="-1" id="zUh-8j-Los"/>
+                                    <action selector="newTabWindow:" target="Voe-Tx-rLC" id="2zX-Cl-R3s"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="New Window" keyEquivalent="n" id="Was-JA-tGl">

--- a/Source/XIB/Base.lproj/SidebarVC.xib
+++ b/Source/XIB/Base.lproj/SidebarVC.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,7 +12,6 @@
             <connections>
                 <outlet property="outlineView" destination="pZg-pX-mra" id="Ekg-N6-wYP"/>
                 <outlet property="scrollView" destination="DCO-bh-M6O" id="oSA-6a-Mfa"/>
-                <outlet property="searchContainer" destination="y6P-iD-BOi" id="bbT-cP-Fs8"/>
                 <outlet property="searchField" destination="y6P-iD-BOi" id="Ixy-ow-4iq"/>
                 <outlet property="view" destination="c22-O7-iKe" id="yAh-ir-K9F"/>
                 <outlet property="xBtn" destination="54F-3B-nyc" id="5D6-yM-oyD"/>
@@ -21,10 +20,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="135" height="377"/>
+            <rect key="frame" x="0.0" y="0.0" width="135" height="433"/>
             <subviews>
                 <button verticalHuggingPriority="750" id="54F-3B-nyc">
-                    <rect key="frame" x="54" y="177" width="27" height="23"/>
+                    <rect key="frame" x="54" y="233" width="27" height="23"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="xmark" catalog="system" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="VeE-kO-M0k">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -38,13 +37,13 @@ Gw
                     </connections>
                 </button>
                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DCO-bh-M6O">
-                    <rect key="frame" x="0.0" y="0.0" width="135" height="377"/>
+                    <rect key="frame" x="0.0" y="0.0" width="135" height="433"/>
                     <clipView key="contentView" drawsBackground="NO" id="INp-hS-uWa">
-                        <rect key="frame" x="0.0" y="0.0" width="135" height="377"/>
+                        <rect key="frame" x="0.0" y="0.0" width="135" height="433"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" mirrorLayoutDirectionWhenInternationalizing="never" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="13" outlineTableColumn="D7v-CS-r19" userInterfaceLayoutDirection="rightToLeft" id="pZg-pX-mra">
-                                <rect key="frame" x="0.0" y="0.0" width="135" height="377"/>
+                                <rect key="frame" x="0.0" y="0.0" width="135" height="433"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="28" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -114,42 +113,33 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="hbV-qX-hTf">
-                    <rect key="frame" x="0.0" y="293" width="135" height="30"/>
-                    <subviews>
-                        <searchField hidden="YES" wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y6P-iD-BOi" customClass="DSFSearchField" customModule="Maktabah" customModuleProvider="target">
-                            <rect key="frame" x="4" y="4" width="127" height="22"/>
-                            <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Table of Contents" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" recentsAutosaveName="TOCSearchField" id="757-Jb-dNx">
-                                <font key="font" metaFont="system"/>
-                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                            </searchFieldCell>
-                            <connections>
-                                <action selector="searchContents:" target="-2" id="0fZ-1R-oUQ"/>
-                            </connections>
-                        </searchField>
-                    </subviews>
+                <searchField hidden="YES" wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y6P-iD-BOi" customClass="DSFSearchField" customModule="Maktabah" customModuleProvider="target">
+                    <rect key="frame" x="4" y="351" width="127" height="22"/>
                     <constraints>
-                        <constraint firstItem="y6P-iD-BOi" firstAttribute="leading" secondItem="B5E-i9-M7f" secondAttribute="leading" constant="4" id="25e-oU-2zo"/>
-                        <constraint firstAttribute="height" constant="30" id="6tZ-Dg-jf1"/>
-                        <constraint firstItem="y6P-iD-BOi" firstAttribute="top" secondItem="hbV-qX-hTf" secondAttribute="top" constant="4" id="GDj-A3-SjQ"/>
-                        <constraint firstAttribute="bottom" secondItem="y6P-iD-BOi" secondAttribute="bottom" constant="4" id="k5q-XP-TOa"/>
-                        <constraint firstItem="B5E-i9-M7f" firstAttribute="trailing" secondItem="y6P-iD-BOi" secondAttribute="trailing" constant="4" id="p8A-hw-vMu"/>
+                        <constraint firstAttribute="height" constant="22" id="iAi-90-aPY"/>
                     </constraints>
-                    <viewLayoutGuide key="safeArea" id="B5E-i9-M7f"/>
-                    <viewLayoutGuide key="layoutMargins" id="qNI-aZ-FKv"/>
-                </customView>
+                    <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" placeholderString="Table of Contents" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" recentsAutosaveName="TOCSearchField" id="757-Jb-dNx">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </searchFieldCell>
+                    <connections>
+                        <action selector="searchContents:" target="-2" id="0fZ-1R-oUQ"/>
+                    </connections>
+                </searchField>
             </subviews>
             <constraints>
-                <constraint firstItem="DCO-bh-M6O" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="1lU-01-2CC"/>
-                <constraint firstItem="hbV-qX-hTf" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="54" id="DFa-g3-Ntc"/>
-                <constraint firstItem="hbV-qX-hTf" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="EAY-f3-ySd"/>
-                <constraint firstAttribute="trailing" secondItem="DCO-bh-M6O" secondAttribute="trailing" id="UFh-hR-zsq"/>
-                <constraint firstAttribute="bottom" secondItem="DCO-bh-M6O" secondAttribute="bottom" id="Ubc-8v-Jam"/>
-                <constraint firstItem="DCO-bh-M6O" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="ViH-xt-OTj"/>
-                <constraint firstAttribute="trailing" secondItem="hbV-qX-hTf" secondAttribute="trailing" id="cNv-QX-rTG"/>
+                <constraint firstItem="Gqs-78-nIh" firstAttribute="trailing" secondItem="DCO-bh-M6O" secondAttribute="trailing" id="UFh-hR-zsq"/>
+                <constraint firstItem="DCO-bh-M6O" firstAttribute="leading" secondItem="Gqs-78-nIh" secondAttribute="leading" id="ViH-xt-OTj"/>
+                <constraint firstItem="DCO-bh-M6O" firstAttribute="bottom" secondItem="Gqs-78-nIh" secondAttribute="bottom" id="ZEu-9f-rch"/>
+                <constraint firstItem="y6P-iD-BOi" firstAttribute="top" secondItem="Gqs-78-nIh" secondAttribute="top" constant="8" id="cb6-DF-66X"/>
+                <constraint firstItem="y6P-iD-BOi" firstAttribute="leading" secondItem="Gqs-78-nIh" secondAttribute="leading" constant="4" id="iH8-GF-QZg"/>
+                <constraint firstItem="Gqs-78-nIh" firstAttribute="trailing" secondItem="y6P-iD-BOi" secondAttribute="trailing" constant="4" id="jey-cg-0mS"/>
+                <constraint firstItem="DCO-bh-M6O" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="sWg-wG-pLH"/>
             </constraints>
-            <point key="canvasLocation" x="-88.5" y="145.5"/>
+            <viewLayoutGuide key="safeArea" id="Gqs-78-nIh"/>
+            <viewLayoutGuide key="layoutMargins" id="8Iq-8L-U9e"/>
+            <point key="canvasLocation" x="-88.5" y="197.5"/>
         </customView>
     </objects>
     <resources>


### PR DESCRIPTION
## Summary
This PR addresses several UI edge-case bugs on macOS and fixes a potential data desynchronization issue when book IDs are migrated. It also cleans up redundant platform-specific compiler directives and prevents memory leaks in observer handling.

---

## Key Changes

### 1. Data Synchronization & Migration Fixes
* **Book ID Migration Handler:** Added `.bookIdMigrated` notification observers across `SearchViewModel`, `ResultsViewModel`, and `OptionSearchVC` to ensure search and bookmarks automatically reload and remain in sync after a book ID migration.
* **Memory Leak Prevention:** Removed non-disposed block-based `NotificationCenter` observers in `BookConnection`. Moved explicit cache invalidations (`invalidateTOC` and `totalPartsCache`) directly to `BookImportView` during migration.
* **Code Cleanup (`LibraryViewModel`):** Removed redundant `#if os(macOS)` conditionals that were nested inside code blocks already scoped to macOS.

### 2. Window & Tab Bar UI Fixes (macOS)
* **Sidebar Inset Adjustment:** Fixed an issue where `SidebarVC` scroll view top insets were incorrectly calculated when the window tab bar was shown, hidden, or resized.
* **New Tab Action State:** Resolved a bug where the "New Tab" menu action became disabled after closing an individual window tab.

---

## Verification
- [x] Verified book ID migration reloads search results and bookmarked items correctly without leaving stale references.
- [x] Verified opening, switching, and closing window tabs on macOS maintains proper scroll view top insets in `SidebarVC`.
- [x] Verified "New Tab" menu item remains enabled after closing a tab.